### PR TITLE
Add specificity metadata and dependencies to questionnaire

### DIFF
--- a/cuestionario_FIXED.json
+++ b/cuestionario_FIXED.json
@@ -17,34 +17,70 @@
         "cluster_id": "CL01",
         "name": "Seguridad y Paz",
         "rationale": "Seguridad humana, protección de la vida y paz territorial",
-        "policy_area_ids": ["P2", "P3", "P7"],
-        "legacy_point_ids": ["P2", "P3", "P7"]
+        "policy_area_ids": [
+          "P2",
+          "P3",
+          "P7"
+        ],
+        "legacy_point_ids": [
+          "P2",
+          "P3",
+          "P7"
+        ]
       },
       {
         "cluster_id": "CL02",
         "name": "Grupos Poblacionales",
         "rationale": "Enfoque diferencial y derechos de grupos específicos",
-        "policy_area_ids": ["P1", "P5", "P6"],
-        "legacy_point_ids": ["P1", "P5", "P6"]
+        "policy_area_ids": [
+          "P1",
+          "P5",
+          "P6"
+        ],
+        "legacy_point_ids": [
+          "P1",
+          "P5",
+          "P6"
+        ]
       },
       {
         "cluster_id": "CL03",
         "name": "Territorio-Ambiente",
         "rationale": "Sostenibilidad territorial y gestión ambiental",
-        "policy_area_ids": ["P4", "P8"],
-        "legacy_point_ids": ["P4", "P8"]
+        "policy_area_ids": [
+          "P4",
+          "P8"
+        ],
+        "legacy_point_ids": [
+          "P4",
+          "P8"
+        ]
       },
       {
         "cluster_id": "CL04",
         "name": "Derechos Sociales & Crisis",
         "rationale": "DESC y gestión de crisis migratoria",
-        "policy_area_ids": ["P9", "P10"],
-        "legacy_point_ids": ["P9", "P10"]
+        "policy_area_ids": [
+          "P9",
+          "P10"
+        ],
+        "legacy_point_ids": [
+          "P9",
+          "P10"
+        ]
       }
     ],
     "policy_area_mapping": {
-      "PA01": "P1", "PA02": "P2", "PA03": "P3", "PA04": "P4", "PA05": "P5",
-      "PA06": "P6", "PA07": "P7", "PA08": "P8", "PA09": "P9", "PA10": "P10"
+      "PA01": "P1",
+      "PA02": "P2",
+      "PA03": "P3",
+      "PA04": "P4",
+      "PA05": "P5",
+      "PA06": "P6",
+      "PA07": "P7",
+      "PA08": "P8",
+      "PA09": "P9",
+      "PA10": "P10"
     }
   },
   "dimensiones": {
@@ -796,7 +832,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -809,7 +846,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -819,7 +857,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -830,7 +869,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -841,7 +881,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -896,7 +937,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -906,7 +948,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -916,7 +959,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -926,7 +970,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -982,7 +1027,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -992,7 +1038,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -1001,7 +1048,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -1059,7 +1107,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -1069,7 +1118,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -1079,7 +1129,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -1089,7 +1140,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -1099,7 +1151,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1155,7 +1208,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -1165,7 +1219,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -1174,7 +1229,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -1184,7 +1240,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1239,7 +1296,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -1248,7 +1306,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -1257,7 +1316,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -1266,7 +1326,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -1276,7 +1337,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -1286,7 +1348,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1342,7 +1405,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -1353,7 +1417,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -1362,7 +1427,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1414,7 +1480,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -1424,7 +1491,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -1433,7 +1501,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1487,7 +1556,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -1496,7 +1566,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -1505,7 +1576,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -1514,7 +1586,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1567,7 +1640,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -1577,7 +1651,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -1586,7 +1661,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1643,7 +1719,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -1652,7 +1729,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -1660,7 +1738,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -1668,7 +1747,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -1722,7 +1802,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -1732,7 +1813,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -1741,12 +1823,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P1",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -1794,7 +1881,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -1803,7 +1891,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -1812,7 +1901,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1864,7 +1954,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -1873,7 +1964,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -1881,7 +1973,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1931,7 +2024,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -1941,7 +2035,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -1950,7 +2045,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2006,7 +2102,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -2014,7 +2111,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -2022,7 +2120,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -2031,7 +2130,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2084,7 +2184,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -2093,7 +2194,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -2102,7 +2204,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2154,7 +2257,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -2162,7 +2266,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -2171,12 +2276,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P1",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -2221,7 +2331,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -2229,7 +2340,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -2238,7 +2350,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2287,7 +2400,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -2295,7 +2409,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -2304,7 +2419,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -2357,7 +2473,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -2366,7 +2483,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -2375,7 +2493,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -2383,7 +2502,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2434,7 +2554,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -2443,7 +2564,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -2452,7 +2574,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2504,7 +2627,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -2513,7 +2637,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -2522,7 +2647,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2574,7 +2700,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -2583,7 +2710,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -2592,7 +2720,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2644,7 +2773,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -2653,7 +2783,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -2662,7 +2793,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2715,7 +2847,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -2724,7 +2857,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -2733,7 +2867,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -2742,7 +2877,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -2751,7 +2887,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2801,7 +2938,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -2810,7 +2948,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -2819,7 +2958,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2870,7 +3010,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -2880,7 +3021,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -2888,7 +3030,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2941,7 +3084,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -2950,7 +3094,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -2959,7 +3104,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -2969,7 +3115,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3021,7 +3168,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -3031,7 +3179,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -3041,7 +3190,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -3051,7 +3201,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3113,7 +3264,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -3126,7 +3278,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -3136,7 +3289,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -3147,7 +3301,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -3158,7 +3313,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -3212,7 +3368,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -3222,7 +3379,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -3232,7 +3390,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -3242,7 +3401,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3298,7 +3458,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -3308,7 +3469,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -3317,7 +3479,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -3376,7 +3539,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -3386,7 +3550,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -3396,7 +3561,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -3406,7 +3572,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -3416,7 +3583,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3471,7 +3639,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -3481,7 +3650,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -3490,7 +3660,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -3500,7 +3671,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3555,7 +3727,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -3564,7 +3737,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -3573,7 +3747,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -3582,7 +3757,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -3592,7 +3768,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -3602,7 +3779,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3657,7 +3835,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -3668,7 +3847,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -3677,7 +3857,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3729,7 +3910,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -3739,7 +3921,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -3748,7 +3931,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3801,7 +3985,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -3810,7 +3995,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -3819,7 +4005,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -3828,7 +4015,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3880,7 +4068,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -3890,7 +4079,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -3899,7 +4089,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3954,7 +4145,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -3963,7 +4155,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -3971,7 +4164,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -3979,7 +4173,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -4031,7 +4226,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -4041,7 +4237,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -4050,12 +4247,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P2",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -4103,7 +4305,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -4112,7 +4315,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -4121,7 +4325,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4173,7 +4378,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -4182,7 +4388,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -4190,7 +4397,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4240,7 +4448,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -4250,7 +4459,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -4259,7 +4469,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4315,7 +4526,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -4323,7 +4535,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -4331,7 +4544,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -4340,7 +4554,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4393,7 +4608,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -4402,7 +4618,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -4411,7 +4628,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4463,7 +4681,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -4471,7 +4690,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -4480,12 +4700,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P2",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -4530,7 +4755,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -4538,7 +4764,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -4547,7 +4774,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4596,7 +4824,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -4604,7 +4833,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -4613,7 +4843,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -4666,7 +4897,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -4675,7 +4907,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -4684,7 +4917,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -4692,7 +4926,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4744,7 +4979,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -4753,7 +4989,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -4762,7 +4999,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4814,7 +5052,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -4823,7 +5062,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -4832,7 +5072,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4885,7 +5126,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -4894,7 +5136,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -4903,7 +5146,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4955,7 +5199,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -4964,7 +5209,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -4973,7 +5219,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5026,7 +5273,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -5035,7 +5283,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -5044,7 +5293,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -5053,7 +5303,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -5062,7 +5313,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5112,7 +5364,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -5121,7 +5374,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -5130,7 +5384,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5182,7 +5437,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -5192,7 +5448,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -5200,7 +5457,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5253,7 +5511,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -5262,7 +5521,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -5271,7 +5531,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -5281,7 +5542,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5334,7 +5596,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -5344,7 +5607,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -5354,7 +5618,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -5364,7 +5629,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5424,7 +5690,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -5437,7 +5704,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -5447,7 +5715,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -5458,7 +5727,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -5469,7 +5739,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -5524,7 +5795,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -5534,7 +5806,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -5544,7 +5817,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -5554,7 +5828,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5610,7 +5885,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -5620,7 +5896,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -5629,7 +5906,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -5688,7 +5966,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -5698,7 +5977,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -5708,7 +5988,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -5718,7 +5999,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -5728,7 +6010,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5783,7 +6066,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -5793,7 +6077,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -5802,7 +6087,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -5812,7 +6098,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5867,7 +6154,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -5876,7 +6164,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -5885,7 +6174,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -5894,7 +6184,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -5904,7 +6195,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -5914,7 +6206,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5970,7 +6263,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -5981,7 +6275,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -5990,7 +6285,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6043,7 +6339,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -6053,7 +6350,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -6062,7 +6360,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6115,7 +6414,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -6124,7 +6424,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -6133,7 +6434,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -6142,7 +6444,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6194,7 +6497,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -6204,7 +6508,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -6213,7 +6518,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6268,7 +6574,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -6277,7 +6584,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -6285,7 +6593,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -6293,7 +6602,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -6344,7 +6654,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -6354,7 +6665,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -6363,12 +6675,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P3",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -6416,7 +6733,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -6425,7 +6743,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -6434,7 +6753,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6486,7 +6806,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -6495,7 +6816,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -6503,7 +6825,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6553,7 +6876,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -6563,7 +6887,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -6572,7 +6897,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6629,7 +6955,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -6637,7 +6964,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -6645,7 +6973,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -6654,7 +6983,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6707,7 +7037,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -6716,7 +7047,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -6725,7 +7057,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6777,7 +7110,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -6785,7 +7119,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -6794,12 +7129,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P3",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -6845,7 +7185,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -6853,7 +7194,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -6862,7 +7204,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6912,7 +7255,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -6920,7 +7264,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -6929,7 +7274,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -6982,7 +7328,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -6991,7 +7338,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -7000,7 +7348,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -7008,7 +7357,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7060,7 +7410,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -7069,7 +7420,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -7078,7 +7430,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7130,7 +7483,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -7139,7 +7493,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -7148,7 +7503,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7201,7 +7557,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -7210,7 +7567,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -7219,7 +7577,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7271,7 +7630,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -7280,7 +7640,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -7289,7 +7650,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7342,7 +7704,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -7351,7 +7714,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -7360,7 +7724,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -7369,7 +7734,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -7378,7 +7744,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7428,7 +7795,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -7437,7 +7805,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -7446,7 +7815,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7498,7 +7868,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -7508,7 +7879,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -7516,7 +7888,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7569,7 +7942,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -7578,7 +7952,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -7587,7 +7962,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -7597,7 +7973,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7649,7 +8026,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -7659,7 +8037,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -7669,7 +8048,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -7679,7 +8059,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7740,7 +8121,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -7753,7 +8135,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -7763,7 +8146,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -7774,7 +8158,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -7785,7 +8170,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -7839,7 +8225,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -7849,7 +8236,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -7859,7 +8247,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -7869,7 +8258,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7925,7 +8315,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -7935,7 +8326,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -7944,7 +8336,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -8003,7 +8396,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -8013,7 +8407,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -8023,7 +8418,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -8033,7 +8429,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -8043,7 +8440,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8099,7 +8497,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -8109,7 +8508,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -8118,7 +8518,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -8128,7 +8529,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8183,7 +8585,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -8192,7 +8595,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -8201,7 +8605,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -8210,7 +8615,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -8220,7 +8626,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -8230,7 +8637,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8286,7 +8694,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -8297,7 +8706,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -8306,7 +8716,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8359,7 +8770,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -8369,7 +8781,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -8378,7 +8791,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8431,7 +8845,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -8440,7 +8855,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -8449,7 +8865,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -8458,7 +8875,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8510,7 +8928,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -8520,7 +8939,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -8529,7 +8949,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8584,7 +9005,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -8593,7 +9015,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -8601,7 +9024,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -8609,7 +9033,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -8660,7 +9085,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -8670,7 +9096,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -8679,12 +9106,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P4",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -8732,7 +9164,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -8741,7 +9174,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -8750,7 +9184,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8802,7 +9237,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -8811,7 +9247,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -8819,7 +9256,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8869,7 +9307,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -8879,7 +9318,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -8888,7 +9328,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8945,7 +9386,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -8953,7 +9395,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -8961,7 +9404,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -8970,7 +9414,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9023,7 +9468,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -9032,7 +9478,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -9041,7 +9488,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9092,7 +9540,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -9100,7 +9549,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -9109,12 +9559,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P4",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -9160,7 +9615,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -9168,7 +9624,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -9177,7 +9634,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9226,7 +9684,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -9234,7 +9693,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -9243,7 +9703,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -9296,7 +9757,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -9305,7 +9767,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -9314,7 +9777,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -9322,7 +9786,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9374,7 +9839,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -9383,7 +9849,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -9392,7 +9859,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9444,7 +9912,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -9453,7 +9922,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -9462,7 +9932,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9515,7 +9986,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -9524,7 +9996,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -9533,7 +10006,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9585,7 +10059,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -9594,7 +10069,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -9603,7 +10079,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9656,7 +10133,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -9665,7 +10143,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -9674,7 +10153,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -9683,7 +10163,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -9692,7 +10173,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9742,7 +10224,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -9751,7 +10234,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -9760,7 +10244,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9812,7 +10297,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -9822,7 +10308,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -9830,7 +10317,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9883,7 +10371,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -9892,7 +10381,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -9901,7 +10391,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -9911,7 +10402,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9964,7 +10456,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -9974,7 +10467,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -9984,7 +10478,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -9994,7 +10489,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10053,7 +10549,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -10066,7 +10563,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -10076,7 +10574,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -10087,7 +10586,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -10098,7 +10598,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -10152,7 +10653,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -10162,7 +10664,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -10172,7 +10675,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -10182,7 +10686,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10238,7 +10743,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -10248,7 +10754,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -10257,7 +10764,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -10316,7 +10824,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -10326,7 +10835,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -10336,7 +10846,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -10346,7 +10857,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -10356,7 +10868,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10411,7 +10924,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -10421,7 +10935,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -10430,7 +10945,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -10440,7 +10956,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10495,7 +11012,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -10504,7 +11022,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -10513,7 +11032,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -10522,7 +11042,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -10532,7 +11053,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -10542,7 +11064,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10598,7 +11121,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -10609,7 +11133,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -10618,7 +11143,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10669,7 +11195,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -10679,7 +11206,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -10688,7 +11216,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10741,7 +11270,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -10750,7 +11280,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -10759,7 +11290,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -10768,7 +11300,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10820,7 +11353,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -10830,7 +11364,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -10839,7 +11374,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10895,7 +11431,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -10904,7 +11441,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -10912,7 +11450,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -10920,7 +11459,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -10971,7 +11511,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -10981,7 +11522,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -10990,12 +11532,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P5",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -11043,7 +11590,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -11052,7 +11600,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -11061,7 +11610,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11113,7 +11663,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -11122,7 +11673,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -11130,7 +11682,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11180,7 +11733,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -11190,7 +11744,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -11199,7 +11754,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11256,7 +11812,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -11264,7 +11821,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -11272,7 +11830,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -11281,7 +11840,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11334,7 +11894,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -11343,7 +11904,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -11352,7 +11914,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11403,7 +11966,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -11411,7 +11975,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -11420,12 +11985,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P5",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -11471,7 +12041,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -11479,7 +12050,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -11488,7 +12060,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11538,7 +12111,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -11546,7 +12120,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -11555,7 +12130,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -11607,7 +12183,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -11616,7 +12193,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -11625,7 +12203,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -11633,7 +12212,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11685,7 +12265,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -11694,7 +12275,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -11703,7 +12285,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11755,7 +12338,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -11764,7 +12348,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -11773,7 +12358,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11826,7 +12412,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -11835,7 +12422,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -11844,7 +12432,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11896,7 +12485,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -11905,7 +12495,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -11914,7 +12505,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11967,7 +12559,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -11976,7 +12569,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -11985,7 +12579,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -11994,7 +12589,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -12003,7 +12599,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12054,7 +12651,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -12063,7 +12661,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -12072,7 +12671,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12124,7 +12724,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -12134,7 +12735,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -12142,7 +12744,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12195,7 +12798,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -12204,7 +12808,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -12213,7 +12818,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -12223,7 +12829,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12275,7 +12882,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -12285,7 +12893,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -12295,7 +12904,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -12305,7 +12915,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12366,7 +12977,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -12379,7 +12991,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -12389,7 +13002,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -12400,7 +13014,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -12411,7 +13026,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -12466,7 +13082,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -12476,7 +13093,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -12486,7 +13104,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -12496,7 +13115,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12552,7 +13172,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -12562,7 +13183,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -12571,7 +13193,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -12630,7 +13253,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -12640,7 +13264,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -12650,7 +13275,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -12660,7 +13286,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -12670,7 +13297,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12725,7 +13353,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -12735,7 +13364,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -12744,7 +13374,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -12754,7 +13385,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12809,7 +13441,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -12818,7 +13451,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -12827,7 +13461,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -12836,7 +13471,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -12846,7 +13482,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -12856,7 +13493,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12912,7 +13550,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -12923,7 +13562,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -12932,7 +13572,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12985,7 +13626,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -12995,7 +13637,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -13004,7 +13647,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13057,7 +13701,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -13066,7 +13711,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -13075,7 +13721,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -13084,7 +13731,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13136,7 +13784,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -13146,7 +13795,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -13155,7 +13805,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13211,7 +13862,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -13220,7 +13872,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -13228,7 +13881,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -13236,7 +13890,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -13288,7 +13943,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -13298,7 +13954,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -13307,12 +13964,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P6",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -13360,7 +14022,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -13369,7 +14032,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -13378,7 +14042,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13430,7 +14095,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -13439,7 +14105,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -13447,7 +14114,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13497,7 +14165,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -13507,7 +14176,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -13516,7 +14186,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13573,7 +14244,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -13581,7 +14253,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -13589,7 +14262,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -13598,7 +14272,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13651,7 +14326,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -13660,7 +14336,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -13669,7 +14346,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13720,7 +14398,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -13728,7 +14407,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -13737,12 +14417,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P6",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -13788,7 +14473,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -13796,7 +14482,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -13805,7 +14492,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13854,7 +14542,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -13862,7 +14551,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -13871,7 +14561,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -13924,7 +14615,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -13933,7 +14625,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -13942,7 +14635,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -13950,7 +14644,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14002,7 +14697,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -14011,7 +14707,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -14020,7 +14717,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14072,7 +14770,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -14081,7 +14780,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -14090,7 +14790,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14143,7 +14844,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -14152,7 +14854,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -14161,7 +14864,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14213,7 +14917,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -14222,7 +14927,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -14231,7 +14937,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14284,7 +14991,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -14293,7 +15001,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -14302,7 +15011,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -14311,7 +15021,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -14320,7 +15031,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14371,7 +15083,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -14380,7 +15093,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -14389,7 +15103,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14441,7 +15156,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -14451,7 +15167,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -14459,7 +15176,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14512,7 +15230,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -14521,7 +15240,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -14530,7 +15250,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -14540,7 +15261,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14592,7 +15314,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -14602,7 +15325,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -14612,7 +15336,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -14622,7 +15347,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14683,7 +15409,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -14696,7 +15423,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -14706,7 +15434,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -14717,7 +15446,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -14728,7 +15458,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -14782,7 +15513,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -14792,7 +15524,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -14802,7 +15535,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -14812,7 +15546,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14868,7 +15603,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -14878,7 +15614,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -14887,7 +15624,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -14946,7 +15684,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -14956,7 +15695,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -14966,7 +15706,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -14976,7 +15717,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -14986,7 +15728,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15041,7 +15784,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -15051,7 +15795,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -15060,7 +15805,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -15070,7 +15816,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15125,7 +15872,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -15134,7 +15882,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -15143,7 +15892,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -15152,7 +15902,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -15162,7 +15913,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -15172,7 +15924,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15228,7 +15981,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -15239,7 +15993,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -15248,7 +16003,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15300,7 +16056,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -15310,7 +16067,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -15319,7 +16077,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15372,7 +16131,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -15381,7 +16141,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -15390,7 +16151,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -15399,7 +16161,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15451,7 +16214,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -15461,7 +16225,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -15470,7 +16235,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15525,7 +16291,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -15534,7 +16301,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -15542,7 +16310,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -15550,7 +16319,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -15600,7 +16370,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -15610,7 +16381,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -15619,12 +16391,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P7",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -15671,7 +16448,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -15680,7 +16458,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -15689,7 +16468,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15741,7 +16521,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -15750,7 +16531,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -15758,7 +16540,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15808,7 +16591,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -15818,7 +16602,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -15827,7 +16612,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15885,7 +16671,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -15893,7 +16680,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -15901,7 +16689,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -15910,7 +16699,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15963,7 +16753,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -15972,7 +16763,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -15981,7 +16773,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16032,7 +16825,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -16040,7 +16834,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -16049,12 +16844,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P7",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -16100,7 +16900,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -16108,7 +16909,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -16117,7 +16919,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16167,7 +16970,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -16175,7 +16979,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -16184,7 +16989,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -16237,7 +17043,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -16246,7 +17053,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -16255,7 +17063,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -16263,7 +17072,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16315,7 +17125,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -16324,7 +17135,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -16333,7 +17145,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16385,7 +17198,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -16394,7 +17208,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -16403,7 +17218,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16456,7 +17272,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -16465,7 +17282,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -16474,7 +17292,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16526,7 +17345,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -16535,7 +17355,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -16544,7 +17365,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16597,7 +17419,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -16606,7 +17429,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -16615,7 +17439,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -16624,7 +17449,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -16633,7 +17459,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16684,7 +17511,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -16693,7 +17521,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -16702,7 +17531,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16754,7 +17584,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -16764,7 +17595,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -16772,7 +17604,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16825,7 +17658,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -16834,7 +17668,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -16843,7 +17678,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -16853,7 +17689,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16905,7 +17742,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -16915,7 +17753,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -16925,7 +17764,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -16935,7 +17775,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16995,7 +17836,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -17008,7 +17850,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -17018,7 +17861,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -17029,7 +17873,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -17040,7 +17885,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -17094,7 +17940,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -17104,7 +17951,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -17114,7 +17962,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -17124,7 +17973,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17180,7 +18030,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -17190,7 +18041,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -17199,7 +18051,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -17258,7 +18111,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -17268,7 +18122,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -17278,7 +18133,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -17288,7 +18144,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -17298,7 +18155,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17353,7 +18211,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -17363,7 +18222,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -17372,7 +18232,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -17382,7 +18243,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17437,7 +18299,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -17446,7 +18309,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -17455,7 +18319,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -17464,7 +18329,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -17474,7 +18340,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -17484,7 +18351,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17540,7 +18408,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -17551,7 +18420,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -17560,7 +18430,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17613,7 +18484,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -17623,7 +18495,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -17632,7 +18505,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17685,7 +18559,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -17694,7 +18569,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -17703,7 +18579,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -17712,7 +18589,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17764,7 +18642,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -17774,7 +18653,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -17783,7 +18663,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17839,7 +18720,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -17848,7 +18730,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -17856,7 +18739,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -17864,7 +18748,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -17914,7 +18799,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -17924,7 +18810,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -17933,12 +18820,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P8",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -17986,7 +18878,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -17995,7 +18888,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -18004,7 +18898,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18056,7 +18951,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -18065,7 +18961,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -18073,7 +18970,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18123,7 +19021,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -18133,7 +19032,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -18142,7 +19042,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18199,7 +19100,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -18207,7 +19109,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -18215,7 +19118,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -18224,7 +19128,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18277,7 +19182,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -18286,7 +19192,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -18295,7 +19202,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18346,7 +19254,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -18354,7 +19263,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -18363,12 +19273,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P8",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -18414,7 +19329,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -18422,7 +19338,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -18431,7 +19348,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18481,7 +19399,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -18489,7 +19408,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -18498,7 +19418,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -18550,7 +19471,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -18559,7 +19481,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -18568,7 +19491,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -18576,7 +19500,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18628,7 +19553,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -18637,7 +19563,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -18646,7 +19573,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18698,7 +19626,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -18707,7 +19636,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -18716,7 +19646,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18769,7 +19700,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -18778,7 +19710,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -18787,7 +19720,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18839,7 +19773,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -18848,7 +19783,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -18857,7 +19793,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18910,7 +19847,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -18919,7 +19857,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -18928,7 +19867,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -18937,7 +19877,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -18946,7 +19887,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18997,7 +19939,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -19006,7 +19949,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -19015,7 +19959,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19067,7 +20012,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -19077,7 +20023,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -19085,7 +20032,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19138,7 +20086,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -19147,7 +20096,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -19156,7 +20106,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -19166,7 +20117,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19218,7 +20170,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -19228,7 +20181,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -19238,7 +20192,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -19248,7 +20203,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19308,7 +20264,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -19321,7 +20278,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -19331,7 +20289,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -19342,7 +20301,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -19353,7 +20313,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -19408,7 +20369,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -19418,7 +20380,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -19428,7 +20391,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -19438,7 +20402,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19494,7 +20459,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -19504,7 +20470,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -19513,7 +20480,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -19572,7 +20540,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -19582,7 +20551,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -19592,7 +20562,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -19602,7 +20573,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -19612,7 +20584,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19668,7 +20641,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -19678,7 +20652,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -19687,7 +20662,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -19697,7 +20673,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19752,7 +20729,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -19761,7 +20739,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -19770,7 +20749,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -19779,7 +20759,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -19789,7 +20770,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -19799,7 +20781,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19855,7 +20838,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -19866,7 +20850,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -19875,7 +20860,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19928,7 +20914,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -19938,7 +20925,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -19947,7 +20935,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20000,7 +20989,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -20009,7 +20999,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -20018,7 +21009,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -20027,7 +21019,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20079,7 +21072,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -20089,7 +21083,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -20098,7 +21093,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20153,7 +21149,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -20162,7 +21159,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -20170,7 +21168,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -20178,7 +21177,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -20228,7 +21228,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -20238,7 +21239,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -20247,12 +21249,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P9",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -20300,7 +21307,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -20309,7 +21317,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -20318,7 +21327,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20370,7 +21380,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -20379,7 +21390,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -20387,7 +21399,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20437,7 +21450,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -20447,7 +21461,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -20456,7 +21471,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20513,7 +21529,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -20521,7 +21538,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -20529,7 +21547,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -20538,7 +21557,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20591,7 +21611,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -20600,7 +21621,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -20609,7 +21631,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20661,7 +21684,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -20669,7 +21693,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -20678,12 +21703,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P9",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -20729,7 +21759,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -20737,7 +21768,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -20746,7 +21778,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20796,7 +21829,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -20804,7 +21838,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -20813,7 +21848,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -20865,7 +21901,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -20874,7 +21911,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -20883,7 +21921,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -20891,7 +21930,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20943,7 +21983,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -20952,7 +21993,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -20961,7 +22003,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21013,7 +22056,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -21022,7 +22066,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -21031,7 +22076,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21084,7 +22130,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -21093,7 +22140,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -21102,7 +22150,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21154,7 +22203,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -21163,7 +22213,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -21172,7 +22223,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21225,7 +22277,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -21234,7 +22287,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -21243,7 +22297,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -21252,7 +22307,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -21261,7 +22317,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21312,7 +22369,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -21321,7 +22379,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -21330,7 +22389,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21382,7 +22442,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -21392,7 +22453,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -21400,7 +22462,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21453,7 +22516,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -21462,7 +22526,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -21471,7 +22536,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -21481,7 +22547,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21534,7 +22601,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -21544,7 +22612,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -21554,7 +22623,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -21564,7 +22634,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21624,7 +22695,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -21637,7 +22709,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -21647,7 +22720,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -21658,7 +22732,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -21669,7 +22744,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -21724,7 +22800,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -21734,7 +22811,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -21744,7 +22822,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -21754,7 +22833,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21810,7 +22890,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -21820,7 +22901,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -21829,7 +22911,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -21887,7 +22970,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -21897,7 +22981,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -21907,7 +22992,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -21917,7 +23003,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -21927,7 +23014,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21982,7 +23070,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -21992,7 +23081,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -22001,7 +23091,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -22011,7 +23102,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22066,7 +23158,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -22075,7 +23168,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -22084,7 +23178,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -22093,7 +23188,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -22103,7 +23199,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -22113,7 +23210,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22170,7 +23268,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -22181,7 +23280,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -22190,7 +23290,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22243,7 +23344,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -22253,7 +23355,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -22262,7 +23365,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22315,7 +23419,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -22324,7 +23429,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -22333,7 +23439,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -22342,7 +23449,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22394,7 +23502,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -22404,7 +23513,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -22413,7 +23523,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22469,7 +23580,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -22478,7 +23590,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -22486,7 +23599,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -22494,7 +23608,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -22545,7 +23660,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -22555,7 +23671,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -22564,12 +23681,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P10",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -22617,7 +23739,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -22626,7 +23749,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -22635,7 +23759,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22687,7 +23812,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -22696,7 +23822,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -22704,7 +23831,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22754,7 +23882,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -22764,7 +23893,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -22773,7 +23903,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22831,7 +23962,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -22839,7 +23971,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -22847,7 +23980,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -22856,7 +23990,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22909,7 +24044,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -22918,7 +24054,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -22927,7 +24064,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22978,7 +24116,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -22986,7 +24125,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -22995,12 +24135,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P10",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -23046,7 +24191,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -23054,7 +24200,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -23063,7 +24210,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23113,7 +24261,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -23121,7 +24270,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -23130,7 +24280,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -23182,7 +24333,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -23191,7 +24343,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -23200,7 +24353,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -23208,7 +24362,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23260,7 +24415,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -23269,7 +24425,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -23278,7 +24435,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23330,7 +24488,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -23339,7 +24498,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -23348,7 +24508,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23401,7 +24562,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -23410,7 +24572,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -23419,7 +24582,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23471,7 +24635,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -23480,7 +24645,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -23489,7 +24655,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23542,7 +24709,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -23551,7 +24719,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -23560,7 +24729,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -23569,7 +24739,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -23578,7 +24749,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23629,7 +24801,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -23638,7 +24811,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -23647,7 +24821,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23699,7 +24874,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -23709,7 +24885,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -23717,7 +24894,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23770,7 +24948,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -23779,7 +24958,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -23788,7 +24968,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -23798,7 +24979,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23850,7 +25032,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -23860,7 +25043,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -23870,7 +25054,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -23880,7 +25065,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {

--- a/questionnaire.json
+++ b/questionnaire.json
@@ -17,34 +17,70 @@
         "cluster_id": "CL01",
         "name": "Seguridad y Paz",
         "rationale": "Seguridad humana, protección de la vida y paz territorial",
-        "policy_area_ids": ["P2", "P3", "P7"],
-        "legacy_point_ids": ["P2", "P3", "P7"]
+        "policy_area_ids": [
+          "P2",
+          "P3",
+          "P7"
+        ],
+        "legacy_point_ids": [
+          "P2",
+          "P3",
+          "P7"
+        ]
       },
       {
         "cluster_id": "CL02",
         "name": "Grupos Poblacionales",
         "rationale": "Enfoque diferencial y derechos de grupos específicos",
-        "policy_area_ids": ["P1", "P5", "P6"],
-        "legacy_point_ids": ["P1", "P5", "P6"]
+        "policy_area_ids": [
+          "P1",
+          "P5",
+          "P6"
+        ],
+        "legacy_point_ids": [
+          "P1",
+          "P5",
+          "P6"
+        ]
       },
       {
         "cluster_id": "CL03",
         "name": "Territorio-Ambiente",
         "rationale": "Sostenibilidad territorial y gestión ambiental",
-        "policy_area_ids": ["P4", "P8"],
-        "legacy_point_ids": ["P4", "P8"]
+        "policy_area_ids": [
+          "P4",
+          "P8"
+        ],
+        "legacy_point_ids": [
+          "P4",
+          "P8"
+        ]
       },
       {
         "cluster_id": "CL04",
         "name": "Derechos Sociales & Crisis",
         "rationale": "DESC y gestión de crisis migratoria",
-        "policy_area_ids": ["P9", "P10"],
-        "legacy_point_ids": ["P9", "P10"]
+        "policy_area_ids": [
+          "P9",
+          "P10"
+        ],
+        "legacy_point_ids": [
+          "P9",
+          "P10"
+        ]
       }
     ],
     "policy_area_mapping": {
-      "PA01": "P1", "PA02": "P2", "PA03": "P3", "PA04": "P4", "PA05": "P5",
-      "PA06": "P6", "PA07": "P7", "PA08": "P8", "PA09": "P9", "PA10": "P10"
+      "PA01": "P1",
+      "PA02": "P2",
+      "PA03": "P3",
+      "PA04": "P4",
+      "PA05": "P5",
+      "PA06": "P6",
+      "PA07": "P7",
+      "PA08": "P8",
+      "PA09": "P9",
+      "PA10": "P10"
     }
   },
   "dimensiones": {
@@ -796,7 +832,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -809,7 +846,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -819,7 +857,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -830,7 +869,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -841,7 +881,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -896,7 +937,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -906,7 +948,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -916,7 +959,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -926,7 +970,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -982,7 +1027,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -992,7 +1038,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -1001,7 +1048,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -1059,7 +1107,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -1069,7 +1118,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -1079,7 +1129,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -1089,7 +1140,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -1099,7 +1151,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1155,7 +1208,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -1165,7 +1219,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -1174,7 +1229,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -1184,7 +1240,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1239,7 +1296,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -1248,7 +1306,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -1257,7 +1316,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -1266,7 +1326,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -1276,7 +1337,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -1286,7 +1348,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1342,7 +1405,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -1353,7 +1417,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -1362,7 +1427,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1414,7 +1480,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -1424,7 +1491,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -1433,7 +1501,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1487,7 +1556,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -1496,7 +1566,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -1505,7 +1576,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -1514,7 +1586,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1567,7 +1640,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -1577,7 +1651,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -1586,7 +1661,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1643,7 +1719,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -1652,7 +1729,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -1660,7 +1738,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -1668,7 +1747,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -1722,7 +1802,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -1732,7 +1813,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -1741,12 +1823,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P1",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -1794,7 +1881,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -1803,7 +1891,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -1812,7 +1901,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1864,7 +1954,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -1873,7 +1964,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -1881,7 +1973,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -1931,7 +2024,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -1941,7 +2035,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -1950,7 +2045,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2006,7 +2102,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -2014,7 +2111,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -2022,7 +2120,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -2031,7 +2130,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2084,7 +2184,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -2093,7 +2194,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -2102,7 +2204,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2154,7 +2257,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -2162,7 +2266,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -2171,12 +2276,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P1",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -2221,7 +2331,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -2229,7 +2340,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -2238,7 +2350,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2287,7 +2400,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -2295,7 +2409,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -2304,7 +2419,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -2357,7 +2473,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -2366,7 +2483,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -2375,7 +2493,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -2383,7 +2502,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2434,7 +2554,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -2443,7 +2564,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -2452,7 +2574,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2504,7 +2627,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -2513,7 +2637,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -2522,7 +2647,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2574,7 +2700,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -2583,7 +2710,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -2592,7 +2720,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2644,7 +2773,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -2653,7 +2783,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -2662,7 +2793,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2715,7 +2847,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -2724,7 +2857,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -2733,7 +2867,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -2742,7 +2877,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -2751,7 +2887,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2801,7 +2938,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -2810,7 +2948,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -2819,7 +2958,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2870,7 +3010,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -2880,7 +3021,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -2888,7 +3030,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -2941,7 +3084,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -2950,7 +3094,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -2959,7 +3104,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -2969,7 +3115,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3021,7 +3168,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -3031,7 +3179,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -3041,7 +3190,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -3051,7 +3201,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3113,7 +3264,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -3126,7 +3278,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -3136,7 +3289,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -3147,7 +3301,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -3158,7 +3313,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -3212,7 +3368,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -3222,7 +3379,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -3232,7 +3390,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -3242,7 +3401,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3298,7 +3458,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -3308,7 +3469,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -3317,7 +3479,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -3376,7 +3539,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -3386,7 +3550,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -3396,7 +3561,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -3406,7 +3572,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -3416,7 +3583,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3471,7 +3639,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -3481,7 +3650,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -3490,7 +3660,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -3500,7 +3671,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3555,7 +3727,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -3564,7 +3737,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -3573,7 +3747,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -3582,7 +3757,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -3592,7 +3768,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -3602,7 +3779,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3657,7 +3835,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -3668,7 +3847,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -3677,7 +3857,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3729,7 +3910,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -3739,7 +3921,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -3748,7 +3931,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3801,7 +3985,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -3810,7 +3995,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -3819,7 +4005,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -3828,7 +4015,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3880,7 +4068,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -3890,7 +4079,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -3899,7 +4089,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -3954,7 +4145,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -3963,7 +4155,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -3971,7 +4164,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -3979,7 +4173,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -4031,7 +4226,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -4041,7 +4237,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -4050,12 +4247,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P2",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -4103,7 +4305,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -4112,7 +4315,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -4121,7 +4325,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4173,7 +4378,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -4182,7 +4388,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -4190,7 +4397,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4240,7 +4448,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -4250,7 +4459,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -4259,7 +4469,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4315,7 +4526,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -4323,7 +4535,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -4331,7 +4544,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -4340,7 +4554,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4393,7 +4608,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -4402,7 +4618,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -4411,7 +4628,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4463,7 +4681,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -4471,7 +4690,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -4480,12 +4700,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P2",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -4530,7 +4755,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -4538,7 +4764,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -4547,7 +4774,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4596,7 +4824,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -4604,7 +4833,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -4613,7 +4843,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -4666,7 +4897,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -4675,7 +4907,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -4684,7 +4917,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -4692,7 +4926,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4744,7 +4979,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -4753,7 +4989,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -4762,7 +4999,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4814,7 +5052,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -4823,7 +5062,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -4832,7 +5072,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4885,7 +5126,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -4894,7 +5136,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -4903,7 +5146,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -4955,7 +5199,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -4964,7 +5209,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -4973,7 +5219,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5026,7 +5273,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -5035,7 +5283,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -5044,7 +5293,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -5053,7 +5303,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -5062,7 +5313,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5112,7 +5364,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -5121,7 +5374,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -5130,7 +5384,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5182,7 +5437,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -5192,7 +5448,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -5200,7 +5457,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5253,7 +5511,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -5262,7 +5521,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -5271,7 +5531,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -5281,7 +5542,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5334,7 +5596,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -5344,7 +5607,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -5354,7 +5618,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -5364,7 +5629,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5424,7 +5690,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -5437,7 +5704,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -5447,7 +5715,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -5458,7 +5727,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -5469,7 +5739,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -5524,7 +5795,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -5534,7 +5806,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -5544,7 +5817,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -5554,7 +5828,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5610,7 +5885,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -5620,7 +5896,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -5629,7 +5906,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -5688,7 +5966,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -5698,7 +5977,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -5708,7 +5988,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -5718,7 +5999,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -5728,7 +6010,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5783,7 +6066,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -5793,7 +6077,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -5802,7 +6087,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -5812,7 +6098,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5867,7 +6154,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -5876,7 +6164,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -5885,7 +6174,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -5894,7 +6184,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -5904,7 +6195,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -5914,7 +6206,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -5970,7 +6263,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -5981,7 +6275,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -5990,7 +6285,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6043,7 +6339,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -6053,7 +6350,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -6062,7 +6360,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6115,7 +6414,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -6124,7 +6424,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -6133,7 +6434,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -6142,7 +6444,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6194,7 +6497,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -6204,7 +6508,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -6213,7 +6518,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6268,7 +6574,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -6277,7 +6584,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -6285,7 +6593,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -6293,7 +6602,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -6344,7 +6654,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -6354,7 +6665,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -6363,12 +6675,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P3",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -6416,7 +6733,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -6425,7 +6743,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -6434,7 +6753,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6486,7 +6806,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -6495,7 +6816,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -6503,7 +6825,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6553,7 +6876,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -6563,7 +6887,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -6572,7 +6897,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6629,7 +6955,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -6637,7 +6964,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -6645,7 +6973,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -6654,7 +6983,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6707,7 +7037,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -6716,7 +7047,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -6725,7 +7057,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6777,7 +7110,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -6785,7 +7119,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -6794,12 +7129,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P3",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -6845,7 +7185,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -6853,7 +7194,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -6862,7 +7204,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -6912,7 +7255,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -6920,7 +7264,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -6929,7 +7274,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -6982,7 +7328,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -6991,7 +7338,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -7000,7 +7348,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -7008,7 +7357,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7060,7 +7410,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -7069,7 +7420,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -7078,7 +7430,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7130,7 +7483,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -7139,7 +7493,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -7148,7 +7503,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7201,7 +7557,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -7210,7 +7567,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -7219,7 +7577,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7271,7 +7630,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -7280,7 +7640,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -7289,7 +7650,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7342,7 +7704,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -7351,7 +7714,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -7360,7 +7724,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -7369,7 +7734,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -7378,7 +7744,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7428,7 +7795,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -7437,7 +7805,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -7446,7 +7815,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7498,7 +7868,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -7508,7 +7879,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -7516,7 +7888,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7569,7 +7942,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -7578,7 +7952,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -7587,7 +7962,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -7597,7 +7973,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7649,7 +8026,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -7659,7 +8037,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -7669,7 +8048,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -7679,7 +8059,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7740,7 +8121,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -7753,7 +8135,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -7763,7 +8146,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -7774,7 +8158,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -7785,7 +8170,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -7839,7 +8225,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -7849,7 +8236,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -7859,7 +8247,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -7869,7 +8258,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -7925,7 +8315,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -7935,7 +8326,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -7944,7 +8336,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -8003,7 +8396,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -8013,7 +8407,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -8023,7 +8418,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -8033,7 +8429,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -8043,7 +8440,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8099,7 +8497,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -8109,7 +8508,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -8118,7 +8518,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -8128,7 +8529,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8183,7 +8585,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -8192,7 +8595,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -8201,7 +8605,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -8210,7 +8615,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -8220,7 +8626,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -8230,7 +8637,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8286,7 +8694,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -8297,7 +8706,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -8306,7 +8716,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8359,7 +8770,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -8369,7 +8781,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -8378,7 +8791,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8431,7 +8845,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -8440,7 +8855,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -8449,7 +8865,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -8458,7 +8875,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8510,7 +8928,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -8520,7 +8939,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -8529,7 +8949,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8584,7 +9005,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -8593,7 +9015,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -8601,7 +9024,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -8609,7 +9033,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -8660,7 +9085,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -8670,7 +9096,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -8679,12 +9106,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P4",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -8732,7 +9164,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -8741,7 +9174,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -8750,7 +9184,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8802,7 +9237,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -8811,7 +9247,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -8819,7 +9256,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8869,7 +9307,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -8879,7 +9318,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -8888,7 +9328,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -8945,7 +9386,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -8953,7 +9395,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -8961,7 +9404,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -8970,7 +9414,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9023,7 +9468,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -9032,7 +9478,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -9041,7 +9488,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9092,7 +9540,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -9100,7 +9549,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -9109,12 +9559,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P4",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -9160,7 +9615,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -9168,7 +9624,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -9177,7 +9634,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9226,7 +9684,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -9234,7 +9693,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -9243,7 +9703,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -9296,7 +9757,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -9305,7 +9767,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -9314,7 +9777,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -9322,7 +9786,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9374,7 +9839,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -9383,7 +9849,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -9392,7 +9859,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9444,7 +9912,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -9453,7 +9922,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -9462,7 +9932,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9515,7 +9986,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -9524,7 +9996,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -9533,7 +10006,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9585,7 +10059,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -9594,7 +10069,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -9603,7 +10079,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9656,7 +10133,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -9665,7 +10143,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -9674,7 +10153,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -9683,7 +10163,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -9692,7 +10173,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9742,7 +10224,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -9751,7 +10234,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -9760,7 +10244,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9812,7 +10297,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -9822,7 +10308,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -9830,7 +10317,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9883,7 +10371,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -9892,7 +10381,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -9901,7 +10391,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -9911,7 +10402,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -9964,7 +10456,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -9974,7 +10467,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -9984,7 +10478,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -9994,7 +10489,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10053,7 +10549,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -10066,7 +10563,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -10076,7 +10574,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -10087,7 +10586,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -10098,7 +10598,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -10152,7 +10653,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -10162,7 +10664,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -10172,7 +10675,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -10182,7 +10686,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10238,7 +10743,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -10248,7 +10754,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -10257,7 +10764,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -10316,7 +10824,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -10326,7 +10835,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -10336,7 +10846,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -10346,7 +10857,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -10356,7 +10868,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10411,7 +10924,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -10421,7 +10935,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -10430,7 +10945,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -10440,7 +10956,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10495,7 +11012,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -10504,7 +11022,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -10513,7 +11032,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -10522,7 +11042,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -10532,7 +11053,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -10542,7 +11064,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10598,7 +11121,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -10609,7 +11133,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -10618,7 +11143,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10669,7 +11195,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -10679,7 +11206,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -10688,7 +11216,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10741,7 +11270,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -10750,7 +11280,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -10759,7 +11290,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -10768,7 +11300,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10820,7 +11353,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -10830,7 +11364,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -10839,7 +11374,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -10895,7 +11431,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -10904,7 +11441,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -10912,7 +11450,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -10920,7 +11459,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -10971,7 +11511,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -10981,7 +11522,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -10990,12 +11532,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P5",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -11043,7 +11590,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -11052,7 +11600,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -11061,7 +11610,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11113,7 +11663,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -11122,7 +11673,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -11130,7 +11682,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11180,7 +11733,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -11190,7 +11744,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -11199,7 +11754,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11256,7 +11812,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -11264,7 +11821,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -11272,7 +11830,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -11281,7 +11840,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11334,7 +11894,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -11343,7 +11904,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -11352,7 +11914,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11403,7 +11966,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -11411,7 +11975,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -11420,12 +11985,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P5",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -11471,7 +12041,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -11479,7 +12050,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -11488,7 +12060,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11538,7 +12111,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -11546,7 +12120,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -11555,7 +12130,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -11607,7 +12183,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -11616,7 +12193,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -11625,7 +12203,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -11633,7 +12212,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11685,7 +12265,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -11694,7 +12275,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -11703,7 +12285,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11755,7 +12338,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -11764,7 +12348,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -11773,7 +12358,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11826,7 +12412,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -11835,7 +12422,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -11844,7 +12432,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11896,7 +12485,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -11905,7 +12495,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -11914,7 +12505,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -11967,7 +12559,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -11976,7 +12569,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -11985,7 +12579,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -11994,7 +12589,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -12003,7 +12599,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12054,7 +12651,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -12063,7 +12661,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -12072,7 +12671,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12124,7 +12724,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -12134,7 +12735,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -12142,7 +12744,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12195,7 +12798,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -12204,7 +12808,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -12213,7 +12818,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -12223,7 +12829,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12275,7 +12882,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -12285,7 +12893,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -12295,7 +12904,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -12305,7 +12915,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12366,7 +12977,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -12379,7 +12991,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -12389,7 +13002,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -12400,7 +13014,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -12411,7 +13026,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -12466,7 +13082,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -12476,7 +13093,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -12486,7 +13104,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -12496,7 +13115,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12552,7 +13172,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -12562,7 +13183,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -12571,7 +13193,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -12630,7 +13253,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -12640,7 +13264,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -12650,7 +13275,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -12660,7 +13286,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -12670,7 +13297,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12725,7 +13353,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -12735,7 +13364,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -12744,7 +13374,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -12754,7 +13385,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12809,7 +13441,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -12818,7 +13451,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -12827,7 +13461,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -12836,7 +13471,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -12846,7 +13482,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -12856,7 +13493,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12912,7 +13550,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -12923,7 +13562,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -12932,7 +13572,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -12985,7 +13626,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -12995,7 +13637,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -13004,7 +13647,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13057,7 +13701,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -13066,7 +13711,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -13075,7 +13721,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -13084,7 +13731,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13136,7 +13784,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -13146,7 +13795,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -13155,7 +13805,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13211,7 +13862,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -13220,7 +13872,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -13228,7 +13881,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -13236,7 +13890,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -13288,7 +13943,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -13298,7 +13954,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -13307,12 +13964,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P6",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -13360,7 +14022,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -13369,7 +14032,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -13378,7 +14042,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13430,7 +14095,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -13439,7 +14105,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -13447,7 +14114,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13497,7 +14165,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -13507,7 +14176,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -13516,7 +14186,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13573,7 +14244,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -13581,7 +14253,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -13589,7 +14262,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -13598,7 +14272,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13651,7 +14326,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -13660,7 +14336,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -13669,7 +14346,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13720,7 +14398,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -13728,7 +14407,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -13737,12 +14417,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P6",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -13788,7 +14473,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -13796,7 +14482,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -13805,7 +14492,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -13854,7 +14542,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -13862,7 +14551,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -13871,7 +14561,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -13924,7 +14615,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -13933,7 +14625,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -13942,7 +14635,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -13950,7 +14644,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14002,7 +14697,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -14011,7 +14707,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -14020,7 +14717,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14072,7 +14770,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -14081,7 +14780,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -14090,7 +14790,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14143,7 +14844,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -14152,7 +14854,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -14161,7 +14864,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14213,7 +14917,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -14222,7 +14927,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -14231,7 +14937,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14284,7 +14991,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -14293,7 +15001,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -14302,7 +15011,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -14311,7 +15021,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -14320,7 +15031,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14371,7 +15083,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -14380,7 +15093,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -14389,7 +15103,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14441,7 +15156,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -14451,7 +15167,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -14459,7 +15176,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14512,7 +15230,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -14521,7 +15240,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -14530,7 +15250,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -14540,7 +15261,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14592,7 +15314,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -14602,7 +15325,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -14612,7 +15336,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -14622,7 +15347,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14683,7 +15409,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -14696,7 +15423,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -14706,7 +15434,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -14717,7 +15446,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -14728,7 +15458,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -14782,7 +15513,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -14792,7 +15524,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -14802,7 +15535,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -14812,7 +15546,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -14868,7 +15603,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -14878,7 +15614,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -14887,7 +15624,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -14946,7 +15684,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -14956,7 +15695,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -14966,7 +15706,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -14976,7 +15717,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -14986,7 +15728,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15041,7 +15784,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -15051,7 +15795,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -15060,7 +15805,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -15070,7 +15816,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15125,7 +15872,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -15134,7 +15882,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -15143,7 +15892,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -15152,7 +15902,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -15162,7 +15913,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -15172,7 +15924,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15228,7 +15981,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -15239,7 +15993,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -15248,7 +16003,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15300,7 +16056,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -15310,7 +16067,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -15319,7 +16077,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15372,7 +16131,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -15381,7 +16141,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -15390,7 +16151,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -15399,7 +16161,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15451,7 +16214,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -15461,7 +16225,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -15470,7 +16235,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15525,7 +16291,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -15534,7 +16301,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -15542,7 +16310,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -15550,7 +16319,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -15600,7 +16370,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -15610,7 +16381,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -15619,12 +16391,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P7",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -15671,7 +16448,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -15680,7 +16458,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -15689,7 +16468,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15741,7 +16521,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -15750,7 +16531,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -15758,7 +16540,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15808,7 +16591,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -15818,7 +16602,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -15827,7 +16612,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15885,7 +16671,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -15893,7 +16680,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -15901,7 +16689,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -15910,7 +16699,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -15963,7 +16753,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -15972,7 +16763,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -15981,7 +16773,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16032,7 +16825,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -16040,7 +16834,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -16049,12 +16844,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P7",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -16100,7 +16900,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -16108,7 +16909,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -16117,7 +16919,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16167,7 +16970,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -16175,7 +16979,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -16184,7 +16989,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -16237,7 +17043,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -16246,7 +17053,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -16255,7 +17063,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -16263,7 +17072,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16315,7 +17125,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -16324,7 +17135,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -16333,7 +17145,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16385,7 +17198,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -16394,7 +17208,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -16403,7 +17218,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16456,7 +17272,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -16465,7 +17282,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -16474,7 +17292,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16526,7 +17345,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -16535,7 +17355,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -16544,7 +17365,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16597,7 +17419,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -16606,7 +17429,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -16615,7 +17439,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -16624,7 +17449,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -16633,7 +17459,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16684,7 +17511,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -16693,7 +17521,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -16702,7 +17531,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16754,7 +17584,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -16764,7 +17595,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -16772,7 +17604,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16825,7 +17658,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -16834,7 +17668,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -16843,7 +17678,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -16853,7 +17689,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16905,7 +17742,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -16915,7 +17753,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -16925,7 +17764,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -16935,7 +17775,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -16995,7 +17836,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -17008,7 +17850,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -17018,7 +17861,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -17029,7 +17873,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -17040,7 +17885,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -17094,7 +17940,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -17104,7 +17951,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -17114,7 +17962,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -17124,7 +17973,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17180,7 +18030,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -17190,7 +18041,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -17199,7 +18051,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -17258,7 +18111,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -17268,7 +18122,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -17278,7 +18133,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -17288,7 +18144,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -17298,7 +18155,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17353,7 +18211,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -17363,7 +18222,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -17372,7 +18232,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -17382,7 +18243,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17437,7 +18299,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -17446,7 +18309,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -17455,7 +18319,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -17464,7 +18329,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -17474,7 +18340,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -17484,7 +18351,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17540,7 +18408,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -17551,7 +18420,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -17560,7 +18430,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17613,7 +18484,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -17623,7 +18495,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -17632,7 +18505,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17685,7 +18559,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -17694,7 +18569,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -17703,7 +18579,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -17712,7 +18589,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17764,7 +18642,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -17774,7 +18653,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -17783,7 +18663,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -17839,7 +18720,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -17848,7 +18730,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -17856,7 +18739,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -17864,7 +18748,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -17914,7 +18799,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -17924,7 +18810,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -17933,12 +18820,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P8",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -17986,7 +18878,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -17995,7 +18888,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -18004,7 +18898,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18056,7 +18951,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -18065,7 +18961,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -18073,7 +18970,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18123,7 +19021,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -18133,7 +19032,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -18142,7 +19042,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18199,7 +19100,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -18207,7 +19109,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -18215,7 +19118,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -18224,7 +19128,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18277,7 +19182,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -18286,7 +19192,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -18295,7 +19202,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18346,7 +19254,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -18354,7 +19263,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -18363,12 +19273,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P8",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -18414,7 +19329,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -18422,7 +19338,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -18431,7 +19348,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18481,7 +19399,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -18489,7 +19408,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -18498,7 +19418,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -18550,7 +19471,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -18559,7 +19481,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -18568,7 +19491,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -18576,7 +19500,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18628,7 +19553,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -18637,7 +19563,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -18646,7 +19573,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18698,7 +19626,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -18707,7 +19636,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -18716,7 +19646,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18769,7 +19700,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -18778,7 +19710,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -18787,7 +19720,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18839,7 +19773,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -18848,7 +19783,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -18857,7 +19793,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18910,7 +19847,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -18919,7 +19857,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -18928,7 +19867,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -18937,7 +19877,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -18946,7 +19887,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -18997,7 +19939,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -19006,7 +19949,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -19015,7 +19959,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19067,7 +20012,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -19077,7 +20023,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -19085,7 +20032,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19138,7 +20086,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -19147,7 +20096,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -19156,7 +20106,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -19166,7 +20117,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19218,7 +20170,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -19228,7 +20181,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -19238,7 +20192,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -19248,7 +20203,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19308,7 +20264,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -19321,7 +20278,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -19331,7 +20289,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -19342,7 +20301,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -19353,7 +20313,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -19408,7 +20369,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -19418,7 +20380,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -19428,7 +20391,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -19438,7 +20402,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19494,7 +20459,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -19504,7 +20470,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -19513,7 +20480,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -19572,7 +20540,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -19582,7 +20551,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -19592,7 +20562,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -19602,7 +20573,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -19612,7 +20584,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19668,7 +20641,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -19678,7 +20652,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -19687,7 +20662,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -19697,7 +20673,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19752,7 +20729,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -19761,7 +20739,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -19770,7 +20749,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -19779,7 +20759,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -19789,7 +20770,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -19799,7 +20781,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19855,7 +20838,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -19866,7 +20850,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -19875,7 +20860,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -19928,7 +20914,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -19938,7 +20925,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -19947,7 +20935,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20000,7 +20989,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -20009,7 +20999,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -20018,7 +21009,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -20027,7 +21019,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20079,7 +21072,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -20089,7 +21083,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -20098,7 +21093,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20153,7 +21149,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -20162,7 +21159,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -20170,7 +21168,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -20178,7 +21177,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -20228,7 +21228,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -20238,7 +21239,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -20247,12 +21249,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P9",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -20300,7 +21307,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -20309,7 +21317,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -20318,7 +21327,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20370,7 +21380,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -20379,7 +21390,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -20387,7 +21399,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20437,7 +21450,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -20447,7 +21461,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -20456,7 +21471,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20513,7 +21529,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -20521,7 +21538,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -20529,7 +21547,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -20538,7 +21557,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20591,7 +21611,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -20600,7 +21621,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -20609,7 +21631,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20661,7 +21684,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -20669,7 +21693,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -20678,12 +21703,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P9",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -20729,7 +21759,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -20737,7 +21768,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -20746,7 +21778,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20796,7 +21829,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -20804,7 +21838,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -20813,7 +21848,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -20865,7 +21901,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -20874,7 +21911,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -20883,7 +21921,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -20891,7 +21930,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -20943,7 +21983,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -20952,7 +21993,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -20961,7 +22003,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21013,7 +22056,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -21022,7 +22066,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -21031,7 +22076,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21084,7 +22130,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -21093,7 +22140,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -21102,7 +22150,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21154,7 +22203,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -21163,7 +22213,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -21172,7 +22223,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21225,7 +22277,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -21234,7 +22287,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -21243,7 +22297,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -21252,7 +22307,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -21261,7 +22317,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21312,7 +22369,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -21321,7 +22379,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -21330,7 +22389,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21382,7 +22442,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -21392,7 +22453,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -21400,7 +22462,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21453,7 +22516,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -21462,7 +22526,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -21471,7 +22536,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -21481,7 +22547,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21534,7 +22601,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -21544,7 +22612,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -21554,7 +22623,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -21564,7 +22634,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21624,7 +22695,8 @@
             "índice de",
             "cobertura de"
           ],
-          "minimum_required": 3
+          "minimum_required": 3,
+          "specificity": "HIGH"
         },
         "verificar_fuentes": {
           "patterns": [
@@ -21637,7 +22709,8 @@
             "SIVIGILA",
             "Ministerio"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "series_temporales": {
           "patterns": [
@@ -21647,7 +22720,8 @@
             "histórico",
             "serie"
           ],
-          "minimum_years": 3
+          "minimum_years": 3,
+          "specificity": "MEDIUM"
         },
         "unidades_medicion": {
           "patterns": [
@@ -21658,7 +22732,8 @@
             "tasa",
             "razón"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "MEDIUM"
         },
         "cobertura": {
           "patterns": [
@@ -21669,7 +22744,8 @@
             "territorial",
             "poblacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -21724,7 +22800,8 @@
             "necesidad de",
             "\\d+%.*población.*sin"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "vacios_informacion": {
           "patterns": [
@@ -21734,7 +22811,8 @@
             "vacío",
             "limitación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "sesgos_explicitos": {
           "patterns": [
@@ -21744,7 +22822,8 @@
             "subestimación",
             "sobreestimación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "calidad_datos": {
           "patterns": [
@@ -21754,7 +22833,8 @@
             "precisión",
             "consistencia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21810,7 +22890,8 @@
             "proyecto.*\\d+",
             "BPIN"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "asignacion_explicita": {
           "patterns": [
@@ -21820,7 +22901,8 @@
             "recursos asignados",
             "presupuesto"
           ],
-          "minimum_required": 2
+          "minimum_required": 2,
+          "specificity": "HIGH"
         },
         "suficiencia_relativa": {
           "patterns": [
@@ -21829,7 +22911,8 @@
             "cierra brecha de",
             "costo estimado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -21887,7 +22970,8 @@
             "funcionarios",
             "talento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "procesos": {
           "patterns": [
@@ -21897,7 +22981,8 @@
             "ruta",
             "flujo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "datos_sistemas": {
           "patterns": [
@@ -21907,7 +22992,8 @@
             "software",
             "SISPRO|SUIFP"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "gobernanza": {
           "patterns": [
@@ -21917,7 +23003,8 @@
             "mesa",
             "instancia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_botella": {
           "patterns": [
@@ -21927,7 +23014,8 @@
             "barrera",
             "dificultad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -21982,7 +23070,8 @@
             "meta.*presupuesto",
             "recursos.*suficientes"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_legales": {
           "patterns": [
@@ -21992,7 +23081,8 @@
             "competencia",
             "marco legal"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_presupuestales": {
           "patterns": [
@@ -22001,7 +23091,8 @@
             "disponibilidad.*recursos",
             "capacidad de endeudamiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_temporales": {
           "patterns": [
@@ -22011,7 +23102,8 @@
             "vigencia",
             "tiempo.*implementación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22066,7 +23158,8 @@
             "matriz",
             "anexo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_responsable": {
           "patterns": [
@@ -22075,7 +23168,8 @@
             "entidad encargada",
             "ejecutor"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_insumo": {
           "patterns": [
@@ -22084,7 +23178,8 @@
             "input",
             "requerimiento"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_output": {
           "patterns": [
@@ -22093,7 +23188,8 @@
             "entregable",
             "resultado esperado"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_calendario": {
           "patterns": [
@@ -22103,7 +23199,8 @@
             "año \\d",
             "plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "columna_costo": {
           "patterns": [
@@ -22113,7 +23210,8 @@
             "monto",
             "\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22170,7 +23268,8 @@
             "herramienta",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_causal": {
           "patterns": [
@@ -22181,7 +23280,8 @@
             "ocasiona",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "poblacion_diana": {
           "patterns": [
@@ -22190,7 +23290,8 @@
             "\\d+\\s*(personas|familias|niños|jóvenes)",
             "dirigido a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22243,7 +23344,8 @@
             "causa.*principal",
             "determinante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causa_raiz_o_mediador": {
           "patterns": [
@@ -22253,7 +23355,8 @@
             "mediador",
             "variable intermedia"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "actividad_vinculada": {
           "patterns": [
@@ -22262,7 +23365,8 @@
             "para intervenir",
             "dirigida a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22315,7 +23419,8 @@
             "consecuencia no intencionada",
             "riesgo de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "cuellos_implementacion": {
           "patterns": [
@@ -22324,7 +23429,8 @@
             "obstáculo",
             "complejidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "conflictos_actividades": {
           "patterns": [
@@ -22333,7 +23439,8 @@
             "contradicción",
             "tensión"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mitigaciones": {
           "patterns": [
@@ -22342,7 +23449,8 @@
             "medida preventiva",
             "control"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22394,7 +23502,8 @@
             "integración",
             "articulación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "secuenciacion": {
           "patterns": [
@@ -22404,7 +23513,8 @@
             "orden",
             "prerrequisito"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_redundancias": {
           "patterns": [
@@ -22413,7 +23523,8 @@
             "eficiencia",
             "optimización"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22469,7 +23580,8 @@
             "numerador.*denominador",
             "metodología de medición"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "fuente_verificacion": {
           "patterns": [
@@ -22478,7 +23590,8 @@
             "sistema de información",
             "registro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base": {
           "patterns": [
@@ -22486,7 +23599,8 @@
             "valor inicial.*\\d+",
             "situación actual.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta": {
           "patterns": [
@@ -22494,7 +23608,8 @@
             "objetivo.*\\d+",
             "valor esperado.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -22545,7 +23660,8 @@
             "beneficiarios.*\\d+",
             "población objetivo.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "dosificacion": {
           "patterns": [
@@ -22555,7 +23671,8 @@
             "dosis",
             "nivel de intervención"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "tamano_efecto": {
           "patterns": [
@@ -22564,12 +23681,17 @@
             "reducción de \\d+%",
             "mejora de \\d+%"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
         "policy_area": "P10",
         "original_id": "D3-Q2"
+      },
+      "dependencias_data": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3"
       }
     },
     {
@@ -22617,7 +23739,8 @@
             "ficha.*proyecto",
             "recursos asignados.*\\$"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "organizacional": {
           "patterns": [
@@ -22626,7 +23749,8 @@
             "dependencia",
             "unidad ejecutora"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "vinculacion_actividades": {
           "patterns": [
@@ -22635,7 +23759,8 @@
             "derivado de",
             "soporta"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22687,7 +23812,8 @@
             "permite generar",
             "factible"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "dosificacion_realista": {
           "patterns": [
@@ -22696,7 +23822,8 @@
             "periodicidad",
             "cantidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "plazos_realistas": {
           "patterns": [
@@ -22704,7 +23831,8 @@
             "plazo de",
             "tiempo de ejecución"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22754,7 +23882,8 @@
             "permite alcanzar",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "mediadores_especificados": {
           "patterns": [
@@ -22764,7 +23893,8 @@
             "a través de",
             "mediante"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mecanismo_explicito": {
           "patterns": [
@@ -22773,7 +23903,8 @@
             "dado que",
             "en la medida que"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22831,7 +23962,8 @@
             "proporción de",
             "nivel de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "linea_base_resultado": {
           "patterns": [
@@ -22839,7 +23971,8 @@
             "situación actual.*\\d+",
             "valor inicial.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "meta_resultado": {
           "patterns": [
@@ -22847,7 +23980,8 @@
             "valor esperado.*\\d+",
             "alcanzar.*\\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ventana_maduracion": {
           "patterns": [
@@ -22856,7 +23990,8 @@
             "\\d{4}",
             "cuatrienio"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22909,7 +24044,8 @@
             "produce",
             "contribuye a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "supuestos": {
           "patterns": [
@@ -22918,7 +24054,8 @@
             "si se cumple",
             "condición necesaria"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "condiciones_habilitantes": {
           "patterns": [
@@ -22927,7 +24064,8 @@
             "depende de",
             "condicionado a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -22978,7 +24116,8 @@
             "con.*recursos.*se puede",
             "suficiente para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "capacidades_vs_meta": {
           "patterns": [
@@ -22986,7 +24125,8 @@
             "equipo técnico",
             "experiencia previa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "evidencia_comparada": {
           "patterns": [
@@ -22995,12 +24135,17 @@
             "experiencia de",
             "benchmark"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
         "policy_area": "P10",
         "original_id": "D4-Q3"
+      },
+      "dependencias_data": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4"
       }
     },
     {
@@ -23046,7 +24191,8 @@
             "soluciona",
             "reduce"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "criterios_exito": {
           "patterns": [
@@ -23054,7 +24200,8 @@
             "se considera exitoso si",
             "umbral de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "umbrales_claros": {
           "patterns": [
@@ -23063,7 +24210,8 @@
             "mínimo aceptable",
             "meta mínima"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23113,7 +24261,8 @@
             "Plan Nacional de Desarrollo",
             "alineado con.*nacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ODS": {
           "patterns": [
@@ -23121,7 +24270,8 @@
             "Objetivos de Desarrollo Sostenible",
             "objetivo \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "coherencia_local": {
           "patterns": [
@@ -23130,7 +24280,8 @@
             "respeta.*lógica",
             "coherente con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         }
       },
       "metadata": {
@@ -23182,7 +24333,8 @@
             "cambio estructural",
             "largo plazo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "ruta_transmision": {
           "patterns": [
@@ -23191,7 +24343,8 @@
             "mediante",
             "cadena"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "rezagos": {
           "patterns": [
@@ -23200,7 +24353,8 @@
             "tiempo de maduración",
             "en \\d+ años"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "medibilidad": {
           "patterns": [
@@ -23208,7 +24362,8 @@
             "indicador de impacto",
             "se observará en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23260,7 +24415,8 @@
             "combina",
             "integra"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "proxies": {
           "patterns": [
@@ -23269,7 +24425,8 @@
             "medición indirecta",
             "variable instrumental"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_mecanismo": {
           "patterns": [
@@ -23278,7 +24435,8 @@
             "refleja",
             "representa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23330,7 +24488,8 @@
             "se mide mediante",
             "como sustituto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validez_externa": {
           "patterns": [
@@ -23339,7 +24498,8 @@
             "representa",
             "correlaciona con"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "limitaciones": {
           "patterns": [
@@ -23348,7 +24508,8 @@
             "sesgo posible",
             "restricción"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23401,7 +24562,8 @@
             "marco.*nacional",
             "acuerdo.*internacional"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "riesgos_sistemicos": {
           "patterns": [
@@ -23410,7 +24572,8 @@
             "crisis",
             "factor macro"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "ruptura_mecanismo": {
           "patterns": [
@@ -23419,7 +24582,8 @@
             "vulnerabilidad",
             "sensibilidad a"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23471,7 +24635,8 @@
             "presupuesto.*permite",
             "capacidad para"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "efectos_no_deseados": {
           "patterns": [
@@ -23480,7 +24645,8 @@
             "externalidad",
             "consecuencia negativa"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "hipotesis_limite": {
           "patterns": [
@@ -23489,7 +24655,8 @@
             "condición máxima",
             "supuesto crítico"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23542,7 +24709,8 @@
             "modelo.*causal",
             "figura \\d+"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "causas": {
           "patterns": [
@@ -23551,7 +24719,8 @@
             "determinante",
             "origen"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "mediadores": {
           "patterns": [
@@ -23560,7 +24729,8 @@
             "eslabón",
             "mecanismo"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "moderadores": {
           "patterns": [
@@ -23569,7 +24739,8 @@
             "condición",
             "depende de"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "supuestos_verificables": {
           "patterns": [
@@ -23578,7 +24749,8 @@
             "comprobable",
             "se puede validar"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23629,7 +24801,8 @@
             "razonable",
             "realista"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "HIGH"
         },
         "sin_saltos": {
           "patterns": [
@@ -23638,7 +24811,8 @@
             "incremental",
             "paso a paso"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "no_milagros": {
           "patterns": [
@@ -23647,7 +24821,8 @@
             "alcanzable",
             "sin suponer"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23699,7 +24874,8 @@
             "incoherencia",
             "problema en"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "validaciones": {
           "patterns": [
@@ -23709,7 +24885,8 @@
             "experimento",
             "test"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "pruebas_mecanismo": {
           "patterns": [
@@ -23717,7 +24894,8 @@
             "verificar causalidad",
             "testear supuesto"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23770,7 +24948,8 @@
             "deriva",
             "alejamiento del objetivo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "layering": {
           "patterns": [
@@ -23779,7 +24958,8 @@
             "acumulación",
             "agregación"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "conversion": {
           "patterns": [
@@ -23788,7 +24968,8 @@
             "cambio de sentido",
             "uso alternativo"
           ],
-          "minimum_required": 0
+          "minimum_required": 0,
+          "specificity": "MEDIUM"
         },
         "mecanismos_correccion": {
           "patterns": [
@@ -23798,7 +24979,8 @@
             "aprendizaje",
             "adaptación"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {
@@ -23850,7 +25032,8 @@
             "beneficiarios",
             "\\d+\\s*(personas|familias)"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_territoriales": {
           "patterns": [
@@ -23860,7 +25043,8 @@
             "región",
             "local"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_culturales": {
           "patterns": [
@@ -23870,7 +25054,8 @@
             "cosmovisión",
             "identidad"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         },
         "restricciones_regulatorias": {
           "patterns": [
@@ -23880,7 +25065,8 @@
             "competencia",
             "ley"
           ],
-          "minimum_required": 1
+          "minimum_required": 1,
+          "specificity": "MEDIUM"
         }
       },
       "metadata": {

--- a/scripts/update_questionnaire_metadata.py
+++ b/scripts/update_questionnaire_metadata.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Utility to update questionnaire metadata with specificity and dependencies."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+ROOT = Path(__file__).resolve().parents[1]
+QUESTIONNAIRE_FILES = [
+    ROOT / "questionnaire.json",
+    ROOT / "cuestionario_FIXED.json",
+]
+
+SPECIFICITY_HIGH_KEYWORDS = {
+    "cuant",  # cuantificacion, cuantitativo
+    "magnitud",
+    "brecha",
+    "trazabilidad",
+    "asignacion",
+    "coherencia",
+    "proporcional",
+    "meta",
+    "impacto",
+    "resultado",
+    "suficiencia",
+    "evidencia",
+    "ambicion",
+    "contradiccion",
+    "cobertura",
+    "linea_base",
+}
+
+SPECIFICITY_MEDIUM_KEYWORDS = {
+    "vacio",
+    "vacío",
+    "limit",
+    "sesgo",
+    "riesgo",
+    "particip",
+    "proceso",
+    "gobernanza",
+    "articulacion",
+    "coordinacion",
+    "capacidad",
+    "enfoque",
+    "seguimiento",
+    "soporte",
+}
+
+SPECIFICITY_LEVELS = ("HIGH", "MEDIUM", "LOW")
+
+SCORING_LEVELS = ["excelente", "bueno", "aceptable", "insuficiente"]
+
+DEFAULT_SCORING = {
+    "excelente": {"min_score": 0.85, "criteria": ""},
+    "bueno": {"min_score": 0.7, "criteria": ""},
+    "aceptable": {"min_score": 0.55, "criteria": ""},
+    "insuficiente": {"min_score": 0.0, "criteria": ""},
+}
+
+DEPENDENCIAS_MAP = {
+    "D3-Q2": {
+        "brecha_diagnosticada": "D1-Q2",
+        "recursos_asignados": "D1-Q3",
+    },
+    "D4-Q3": {
+        "inversion_total": "D1-Q3",
+        "capacidad_mencionada": "D1-Q4",
+    },
+}
+
+
+def assign_specificity(group_name: str) -> str:
+    name = group_name.lower()
+    if any(keyword in name for keyword in SPECIFICITY_HIGH_KEYWORDS):
+        return "HIGH"
+    if any(keyword in name for keyword in SPECIFICITY_MEDIUM_KEYWORDS):
+        return "MEDIUM"
+    return "MEDIUM"
+
+
+def normalize_scoring(scoring: Dict[str, Any]) -> Dict[str, Any]:
+    normalized: Dict[str, Any] = {}
+    for level in SCORING_LEVELS:
+        entry = scoring.get(level, {})
+        entry_dict = dict(entry) if isinstance(entry, dict) else {}
+        # Preserve existing values but guarantee required keys
+        if "min_score" not in entry_dict:
+            entry_dict["min_score"] = DEFAULT_SCORING[level]["min_score"]
+        if "criteria" not in entry_dict:
+            entry_dict["criteria"] = DEFAULT_SCORING[level]["criteria"]
+        normalized[level] = entry_dict
+    # Append any additional scoring categories after the normalized block
+    for level, entry in scoring.items():
+        if level not in normalized:
+            normalized[level] = entry
+    return normalized
+
+
+def update_verification_blocks(question: Dict[str, Any]) -> bool:
+    updated = False
+    for key, value in list(question.items()):
+        if not key.startswith("verificacion"):
+            continue
+        if isinstance(value, dict):
+            for group_name, group_data in value.items():
+                if isinstance(group_data, dict) and "patterns" in group_data:
+                    specificity = assign_specificity(group_name)
+                    if group_data.get("specificity") != specificity:
+                        group_data["specificity"] = specificity
+                        updated = True
+    return updated
+
+
+def apply_updates(path: Path) -> bool:
+    if not path.exists():
+        return False
+    changed = False
+    data = json.loads(path.read_text(encoding="utf-8"))
+
+    preguntas = data.get("preguntas_base", [])
+    if isinstance(preguntas, list):
+        for question in preguntas:
+            if not isinstance(question, dict):
+                continue
+            # Update verification specificity
+            if update_verification_blocks(question):
+                changed = True
+            # Normalize scoring structure
+            scoring = question.get("scoring")
+            if isinstance(scoring, dict):
+                normalized = normalize_scoring(scoring)
+                if normalized != scoring:
+                    question["scoring"] = normalized
+                    changed = True
+            # Apply dependencies if applicable
+            metadata = question.get("metadata", {})
+            original_id = metadata.get("original_id") if isinstance(metadata, dict) else None
+            if original_id in DEPENDENCIAS_MAP:
+                deps = DEPENDENCIAS_MAP[original_id]
+                if question.get("dependencias_data") != deps:
+                    question["dependencias_data"] = deps
+                    changed = True
+    if changed:
+        path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return changed
+
+
+def main() -> None:
+    any_changed = False
+    for file_path in QUESTIONNAIRE_FILES:
+        if apply_updates(file_path):
+            print(f"Updated {file_path.relative_to(ROOT)}")
+            any_changed = True
+        else:
+            print(f"No changes required for {file_path.relative_to(ROOT)}")
+    if not any_changed:
+        print("No updates were necessary")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- tag each verification block with a specificity weight to feed Bayesian scoring in the choreographer
- add explicit data dependencies for D3-Q2 and D4-Q3 so cross-dimension checks can be orchestrated
- provide a utility script to normalize scoring dictionaries across both questionnaire variants

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fa31f1afa48328832230dd72bb2456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a utility script to enhance questionnaire metadata with specificity classification, normalized scoring structures, and dependency mappings. This internal tool automates metadata updates across questionnaire files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->