### PR TITLE
Fix choreographer startup by importing CausalDimension

### DIFF
--- a/choreographer.py
+++ b/choreographer.py
@@ -55,8 +55,11 @@ from embedding_policy import (
 )
 from semantic_chunking_policy import (
     SemanticProcessor, BayesianEvidenceIntegrator,
-    PolicyDocumentAnalyzer, SemanticConfig
+    PolicyDocumentAnalyzer, SemanticConfig, CausalDimension
 )
+
+if 'CausalDimension' not in globals():
+    raise ImportError("CausalDimension is required by choreographer startup")
 from teoria_cambio import (
     TeoriaCambio,
     AdvancedDAGValidator, IndustrialGradeValidator, GraphType


### PR DESCRIPTION
## Summary
- import `CausalDimension` from `semantic_chunking_policy` so the choreographer can build dimension mappings
- add a startup guard that raises a clear `ImportError` if `CausalDimension` is missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa45b46a00832896743f268cb8af10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Exposed internal dimension component to the public import surface for broader accessibility within the system.
  * Added startup validation to ensure required components are available before initialization proceeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->