### PR TITLE
Add advanced graph node schema and serializer compliance

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -2,7 +2,7 @@
 ## Commit 3: Schema Definitions
 
 **Generated:** 2025-10-22  
-**Total Schemas:** 19 JSON Schema files  
+**Total Schemas:** 20 JSON Schema files
 **Validation Level:** STRICT  
 **Format:** JSON Schema Draft-07
 
@@ -27,9 +27,10 @@ schemas/
 ├── embedding_policy/               (2 schemas - IN PROGRESS)
 │   ├── semantic_chunk.schema.json
 │   └── bayesian_evaluation.schema.json
-├── teoria_cambio/                  (2 schemas - IN PROGRESS)
+├── teoria_cambio/                  (3 schemas - IN PROGRESS)
 │   ├── validacion_resultado.schema.json
-│   └── monte_carlo_result.schema.json
+│   ├── monte_carlo_result.schema.json
+│   └── advanced_graph_node.schema.json
 ├── dereck_beach/                   (2 schemas - IN PROGRESS)
 │   ├── meta_node.schema.json
 │   └── audit_result.schema.json
@@ -43,7 +44,7 @@ schemas/
 
 ---
 
-## ✅ COMPLETED SCHEMAS (6/19)
+## ✅ COMPLETED SCHEMAS (7/20)
 
 ### **financiero_viabilidad/** (5 schemas)
 
@@ -79,9 +80,14 @@ schemas/
    - Properties: question_id (P#-D#-Q# pattern), qualitative_note (EXCELENTE/BUENO/ACEPTABLE/INSUFICIENTE), quantitative_score (0.0-3.0), evidence, explanation (150-3000 chars), confidence, scoring_modality (TYPE_A-F), elements_found, modules_executed, execution_time, execution_chain
    - Doctoral-level explanation with 150-300 word requirement
 
+7. **advanced_graph_node.schema.json** (80 lines)
+   - Nodo enriquecido del AdvancedDAGValidator
+   - Properties: name, dependencies (array ordenada de strings únicas), metadata.created (date-time), metadata.confidence (0-1), role (variable/insumo/proceso/producto/resultado/causalidad)
+   - `additionalProperties` restringe los metadatos a primitivos JSON
+
 ---
 
-## 🔄 REMAINING SCHEMAS (13/19)
+## 🔄 REMAINING SCHEMAS (13/20)
 
 ### Priority 1: Report Assembly Outputs (2 schemas)
 - **meso_cluster.schema.json** - Cluster aggregation (MesoLevelCluster dataclass)
@@ -193,11 +199,11 @@ ajv validate -s schemas/financiero_viabilidad/causal_node.schema.json \
 | analyzer_one | 2 | TBD | ⏳ 0% |
 | contradiction_deteccion | 2 | TBD | ⏳ 0% |
 | embedding_policy | 2 | TBD | ⏳ 0% |
-| teoria_cambio | 2 | TBD | ⏳ 0% |
+| teoria_cambio | 3 | TBD | ⏳ 0% |
 | dereck_beach | 2 | TBD | ⏳ 0% |
 | policy_processor | 1 | TBD | ⏳ 0% |
 | report_assembly | 3 | 98 | ⏳ 33% |
-| **TOTAL** | **19** | **410+** | **32%** |
+| **TOTAL** | **20** | **430+** | **35%** |
 
 ---
 
@@ -222,6 +228,6 @@ ajv validate -s schemas/financiero_viabilidad/causal_node.schema.json \
 
 ---
 
-**Status:** 6/19 schemas complete (32%)  
+**Status:** 7/20 schemas complete (35%)
 **Next:** Complete report_assembly + core producer schemas  
 **Target:** 100% schema coverage for Commit 3 completion

--- a/schemas/teoria_cambio/advanced_graph_node.schema.json
+++ b/schemas/teoria_cambio/advanced_graph_node.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://saaaaaa.policy.analysis/schemas/teoria_cambio/advanced_graph_node.schema.json",
+  "title": "AdvancedGraphNode",
+  "description": "Nodo enriquecido utilizado por AdvancedDAGValidator con dependencias únicas, metadatos normalizados y rol semántico compatible con la jerarquía de teoría de cambio.",
+  "type": "object",
+  "required": ["name", "dependencies", "metadata", "role"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Identificador único del nodo dentro del DAG de teoría de cambio",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "dependencies": {
+      "type": "array",
+      "description": "Lista ordenada de nodos antecesores (set serializado en orden lexicográfico estable).",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200
+      },
+      "uniqueItems": true
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Metadatos del nodo con valores primitivos (timestamps ISO 8601 y confianza en [0,1]).",
+      "required": ["created", "confidence"],
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Fecha y hora de creación en formato ISO 8601."
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "description": "Nivel de confianza asociado al nodo (0 = sin evidencia, 1 = evidencia concluyente)."
+        }
+      },
+      "additionalProperties": {
+        "anyOf": [
+          {"type": "string"},
+          {"type": "number"},
+          {"type": "boolean"},
+          {"type": "null"}
+        ]
+      }
+    },
+    "role": {
+      "type": "string",
+      "description": "Rol semántico del nodo dentro de la jerarquía axiomática",
+      "enum": [
+        "variable",
+        "insumo",
+        "proceso",
+        "producto",
+        "resultado",
+        "causalidad"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "examples": [
+    {
+      "name": "reduccion_vbg",
+      "dependencies": ["comisarias_funcionales"],
+      "metadata": {
+        "created": "2025-10-22T12:34:56+00:00",
+        "confidence": 0.92,
+        "evidence_source": "Encuesta Nacional 2024"
+      },
+      "role": "resultado"
+    }
+  ]
+}

--- a/tests/test_advanced_graph_node_schema.py
+++ b/tests/test_advanced_graph_node_schema.py
@@ -1,0 +1,64 @@
+from datetime import datetime, timezone
+
+import pytest
+
+pytest.importorskip("networkx")
+pytest.importorskip("numpy")
+pytest.importorskip("scipy")
+
+from teoria_cambio import AdvancedGraphNode, AdvancedDAGValidator
+
+
+def test_advanced_graph_node_serialization_defaults_and_sorting():
+    node = AdvancedGraphNode(
+        name="autonomia_economica",
+        dependencies={"reduccion_vbg", "aumento_participacion"},
+        metadata={"confidence": "0.75", "note": {"fuente": "Plan 2024"}},
+        role="RESULTADO",
+    )
+
+    payload = node.to_serializable_dict()
+
+    assert payload["name"] == "autonomia_economica"
+    assert payload["dependencies"] == [
+        "aumento_participacion",
+        "reduccion_vbg",
+    ]
+    assert isinstance(payload["metadata"]["created"], str)
+    assert payload["metadata"]["confidence"] == pytest.approx(0.75)
+    assert payload["metadata"]["note"] == "{'fuente': 'Plan 2024'}"
+    assert payload["role"] == "resultado"
+
+
+def test_export_nodes_enforces_schema_and_populates_defaults():
+    validator = AdvancedDAGValidator()
+    validator.add_node("recursos_financieros", role="insumo")
+    validator.add_node(
+        "reduccion_vbg",
+        dependencies={"recursos_financieros"},
+        metadata={
+            "created": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "confidence": 1.2,
+            "evidencia": ["Encuesta 2023"],
+        },
+        role="resultado",
+    )
+
+    nodes = validator.export_nodes(validate=True)
+
+    assert len(nodes) == 2
+    resultado_node = next(node for node in nodes if node["name"] == "reduccion_vbg")
+    assert resultado_node["dependencies"] == ["recursos_financieros"]
+    assert resultado_node["metadata"]["confidence"] == pytest.approx(1.0)
+    assert resultado_node["metadata"]["evidencia"] == "['Encuesta 2023']"
+    assert resultado_node["metadata"]["created"].startswith("2024-01-01")
+    # Defaults populated for nodes without explicit metadata
+    insumo_node = next(node for node in nodes if node["name"] == "recursos_financieros")
+    assert "created" in insumo_node["metadata"]
+    assert insumo_node["metadata"]["confidence"] == pytest.approx(1.0)
+    assert validator.last_serialized_nodes == nodes
+
+
+def test_advanced_graph_node_rejects_unknown_role():
+    with pytest.raises(ValueError):
+        AdvancedGraphNode(name="actor_externo", dependencies=set(), role="actor")


### PR DESCRIPTION
## Summary
- define a JSON Schema for AdvancedGraphNode and document it in schemas/README with refreshed counts
- harden AdvancedGraphNode/AdvancedDAGValidator serialization so metadata defaults are enforced, JSON primitives are emitted, and schema validation can run during stochastic evaluation
- add regression tests covering serialization semantics and schema compliance helpers

## Testing
- pytest tests/test_advanced_graph_node_schema.py *(skipped: optional deps missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa458298a08328b389af8a48393b30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added node export functionality with optional JSON schema validation for graph nodes
  * Enhanced metadata normalization for improved data consistency

* **Documentation**
  * Updated schema documentation: 7 of 20 schemas now completed (35% progress); added new advanced graph node schema definition

* **Tests**
  * Added comprehensive validation tests for node serialization, schema enforcement, and role validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->