### PR TITLE
Fix CausalDimension import source

### DIFF
--- a/choreographer.py
+++ b/choreographer.py
@@ -45,8 +45,8 @@ from dereck_beach import (
     BayesianMechanismInference, CDAFFramework
 )
 from policy_processor import (
-    IndustrialPolicyProcessor, BayesianEvidenceScorer, 
-    PolicyTextProcessor, ProcessorConfig
+    IndustrialPolicyProcessor, BayesianEvidenceScorer,
+    PolicyTextProcessor, ProcessorConfig, CausalDimension
 )
 from embedding_policy import (
     AdvancedSemanticChunker, BayesianNumericalAnalyzer,


### PR DESCRIPTION
## Summary
- import `CausalDimension` from `policy_processor` so the choreographer references the defined enum
- stop importing `CausalDimension` from `semantic_chunking_policy`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa5d6c28208328b9145b39217976c2