### PR TITLE
Add comprehensive micro recommendation rules

### DIFF
--- a/config/recommendation_rules.json
+++ b/config/recommendation_rules.json
@@ -1,0 +1,2231 @@
+{
+  "version": "1.0",
+  "rules": [
+    {
+      "rule_id": "REC-MICRO-PA01-DIM01-LB01",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA01",
+        "dim_id": "DIM01",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q001}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: el diagnóstico no consolida línea base cuantitativa y series verificables sobre brechas de género, violencia basada en género y autonomía económica, ni documenta fuentes acreditadas y supuestos de validez.",
+        "intervention": "Levantar y normalizar las líneas base de brechas de género, violencia basada en género y autonomía económica integrando registros de Observatorio de Género, DANE y Medicina Legal en el Repositorio del Observatorio de Género municipal, con metadatos de cobertura, periodicidad y responsable homologados con Planeación y Hacienda.",
+        "indicator": {
+          "name": "PA01-DIM01 líneas base homologadas",
+          "baseline": null,
+          "target": 0.85,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de la Mujer Municipal",
+          "role": "lidera la política pública de género",
+          "partners": [
+            "Secretaría de Planeación",
+            "Secretaría de Hacienda",
+            "Alta Consejería de la Mujer"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Ficha técnica de línea base sobre brechas de género, violencia basada en género y autonomía económica",
+          "Repositorio del Observatorio de Género municipal con metadatos aprobados",
+          "Acta del comité técnico intersectorial de datos"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA01-DIM02-ACT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA01",
+        "dim_id": "DIM02",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q006}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: las actividades priorizadas no describen el instrumento denominado ruta integral de prevención y atención a violencias basadas en género con población mujeres y personas LGBTIQ+ en riesgo, dosis y lógica causal para lograr reducción de la violencia de género.",
+        "intervention": "Documentar el portafolio de actividades del instrumento ruta integral de prevención y atención a violencias basadas en género en fichas operativas con objetivo causal, población objetivo, dosis (brigadas mensuales y acompañamiento psicosocial continuo), costos y responsables, integradas al sistema SIG Mujer y Sistema de Alertas Tempranas y validadas con Planeación.",
+        "indicator": {
+          "name": "PA01-DIM02 actividades con ficha completa",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de la Mujer Municipal",
+          "role": "lidera la política pública de género",
+          "partners": [
+            "Secretaría de Planeación",
+            "Secretaría de Hacienda",
+            "Alta Consejería de la Mujer"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Fichas operativas del instrumento ruta integral de prevención y atención a violencias basadas en género",
+          "Reporte del SIG Mujer y Sistema de Alertas Tempranas",
+          "Acta de comité operativo intersectorial"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA01-DIM03-BPIN",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA01",
+        "dim_id": "DIM03",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q011}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los productos priorizados carecen de ficha BPIN para centros de atención, casas refugio y unidades móviles para mujeres, sin línea base, meta y fuentes de verificación trazables.",
+        "intervention": "Radicar y validar las fichas BPIN de centros de atención, casas refugio y unidades móviles para mujeres con trazabilidad presupuestal (BPIN, Fondo de Seguridad y recursos SGP), responsables definidos y articulación al Plan Plurianual de Inversiones.",
+        "indicator": {
+          "name": "PA01-DIM03 productos con BPIN y FV",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de la Mujer Municipal",
+          "role": "lidera la política pública de género",
+          "partners": [
+            "Secretaría de Planeación",
+            "Secretaría de Hacienda",
+            "Alta Consejería de la Mujer"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Registro BPIN de centros de atención, casas refugio y unidades móviles para mujeres",
+          "Plan Plurianual de Inversiones con codificación BPIN",
+          "Concepto de viabilidad financiera suscrito"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA01-DIM04-RESULT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA01",
+        "dim_id": "DIM04",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q016}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los resultados esperados no enlazan los productos con reducción de violencias y fortalecimiento de autonomía económica femenina ni justifican las metas bajo los supuestos de coordinación con comisarías de familia, justicia y servicios sociales.",
+        "intervention": "Construir matriz producto-resultado que conecte entregables con reducción de violencias y fortalecimiento de autonomía económica femenina, defina indicadores con línea base y metas, y documente supuestos de coordinación con comisarías de familia, justicia y servicios sociales con responsables y cronograma.",
+        "indicator": {
+          "name": "PA01-DIM04 resultados con matriz válida",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de la Mujer Municipal",
+          "role": "lidera la política pública de género",
+          "partners": [
+            "Secretaría de Planeación",
+            "Secretaría de Hacienda",
+            "Alta Consejería de la Mujer"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Matriz producto-resultado validada",
+          "Acta del comité de seguimiento y evaluación",
+          "Modelo de consistencia de metas para reducción de violencias y fortalecimiento de autonomía económica femenina"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA01-DIM05-RIESGOS",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA01",
+        "dim_id": "DIM05",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q021}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los impactos previstos en garantía de derechos y seguridad de las mujeres no modelan rezagos temporales ni riesgos críticos como revictimización, subregistro y represalias de agresores.",
+        "intervention": "Diseñar matriz de impactos y riesgos para garantía de derechos y seguridad de las mujeres con escenarios probabilísticos, análisis de revictimización, subregistro y represalias de agresores y planes de contingencia articulados al Comité de Justicia de Género y Mesa de DDHH.",
+        "indicator": {
+          "name": "PA01-DIM05 impactos con riesgos modelados",
+          "baseline": null,
+          "target": 0.7,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de la Mujer Municipal",
+          "role": "lidera la política pública de género",
+          "partners": [
+            "Secretaría de Planeación",
+            "Secretaría de Hacienda",
+            "Alta Consejería de la Mujer"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T3"
+        },
+        "verification": [
+          "Matriz de impactos y riesgos de garantía de derechos y seguridad de las mujeres",
+          "Escenarios contrafactuales validados por el Comité de Justicia de Género y Mesa de DDHH",
+          "Acta del comité de gestión del riesgo"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA01-DIM06-DAG",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA01",
+        "dim_id": "DIM06",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q026}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: no existe DAG causal que ordene prevención, protección, justicia y autonomía económica de mujeres ni explicite moderadores como capacidad institucional de comisarías y disponibilidad presupuestal territorial.",
+        "intervention": "Elaborar y validar un DAG para prevención, protección, justicia y autonomía económica de mujeres con nodos de insumo a impacto, supuestos explícitos, moderadores (capacidad institucional de comisarías y disponibilidad presupuestal territorial) y bitácora de pruebas de consistencia.",
+        "indicator": {
+          "name": "PA01-DIM06 DAG validado",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de la Mujer Municipal",
+          "role": "lidera la política pública de género",
+          "partners": [
+            "Secretaría de Planeación",
+            "Secretaría de Hacienda",
+            "Alta Consejería de la Mujer"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "DAG validado para prevención, protección, justicia y autonomía económica de mujeres",
+          "Bitácora de supuestos y versiones firmada",
+          "Informe de revisión externa de coherencia causal"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA02-DIM01-LB01",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA02",
+        "dim_id": "DIM01",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q031}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: el diagnóstico no consolida línea base cuantitativa y series verificables sobre tasas de homicidio, hurtos y violencia en zonas priorizadas, ni documenta fuentes acreditadas y supuestos de validez.",
+        "intervention": "Levantar y normalizar las líneas base de tasas de homicidio, hurtos y violencia en zonas priorizadas integrando registros de SIEDCO, Medicina Legal y Observatorio de Seguridad en el Sistema Integrado de Seguridad y Convivencia municipal, con metadatos de cobertura, periodicidad y responsable homologados con Planeación y Hacienda.",
+        "indicator": {
+          "name": "PA02-DIM01 líneas base homologadas",
+          "baseline": null,
+          "target": 0.85,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Gobierno Municipal",
+          "role": "coordina seguridad y convivencia",
+          "partners": [
+            "Policía Nacional",
+            "Unidad de Derechos Humanos",
+            "Alto Consejero para la Seguridad"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Ficha técnica de línea base sobre tasas de homicidio, hurtos y violencia en zonas priorizadas",
+          "Sistema Integrado de Seguridad y Convivencia municipal con metadatos aprobados",
+          "Acta del comité técnico intersectorial de datos"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA02-DIM02-ACT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA02",
+        "dim_id": "DIM02",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q036}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: las actividades priorizadas no describen el instrumento denominado plan integral de seguridad y convivencia articulado con fuerza pública con población barrios críticos, víctimas de delitos y actores comunitarios, dosis y lógica causal para lograr reducción de homicidios y delitos de alto impacto.",
+        "intervention": "Documentar el portafolio de actividades del instrumento plan integral de seguridad y convivencia articulado con fuerza pública en fichas operativas con objetivo causal, población objetivo, dosis (operativos semanales y jornadas preventivas trimestrales), costos y responsables, integradas al sistema SIPARES y Observatorio de Seguridad Territorial y validadas con Planeación.",
+        "indicator": {
+          "name": "PA02-DIM02 actividades con ficha completa",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Gobierno Municipal",
+          "role": "coordina seguridad y convivencia",
+          "partners": [
+            "Policía Nacional",
+            "Unidad de Derechos Humanos",
+            "Alto Consejero para la Seguridad"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Fichas operativas del instrumento plan integral de seguridad y convivencia articulado con fuerza pública",
+          "Reporte del SIPARES y Observatorio de Seguridad Territorial",
+          "Acta de comité operativo intersectorial"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA02-DIM03-BPIN",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA02",
+        "dim_id": "DIM03",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q041}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los productos priorizados carecen de ficha BPIN para frentes de seguridad, CAI móviles y sistemas de videovigilancia, sin línea base, meta y fuentes de verificación trazables.",
+        "intervention": "Radicar y validar las fichas BPIN de frentes de seguridad, CAI móviles y sistemas de videovigilancia con trazabilidad presupuestal (BPIN, Fondo de Seguridad y cofinanciación del Ministerio del Interior), responsables definidos y articulación al Plan Plurianual de Inversiones.",
+        "indicator": {
+          "name": "PA02-DIM03 productos con BPIN y FV",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Gobierno Municipal",
+          "role": "coordina seguridad y convivencia",
+          "partners": [
+            "Policía Nacional",
+            "Unidad de Derechos Humanos",
+            "Alto Consejero para la Seguridad"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Registro BPIN de frentes de seguridad, CAI móviles y sistemas de videovigilancia",
+          "Plan Plurianual de Inversiones con codificación BPIN",
+          "Concepto de viabilidad financiera suscrito"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA02-DIM04-RESULT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA02",
+        "dim_id": "DIM04",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q046}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los resultados esperados no enlazan los productos con mejoras en convivencia y disminución de delitos priorizados ni justifican las metas bajo los supuestos de operatividad conjunta con Fiscalía y justicia.",
+        "intervention": "Construir matriz producto-resultado que conecte entregables con mejoras en convivencia y disminución de delitos priorizados, defina indicadores con línea base y metas, y documente supuestos de operatividad conjunta con Fiscalía y justicia con responsables y cronograma.",
+        "indicator": {
+          "name": "PA02-DIM04 resultados con matriz válida",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Gobierno Municipal",
+          "role": "coordina seguridad y convivencia",
+          "partners": [
+            "Policía Nacional",
+            "Unidad de Derechos Humanos",
+            "Alto Consejero para la Seguridad"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Matriz producto-resultado validada",
+          "Acta del comité de seguimiento y evaluación",
+          "Modelo de consistencia de metas para mejoras en convivencia y disminución de delitos priorizados"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA02-DIM05-RIESGOS",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA02",
+        "dim_id": "DIM05",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q051}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los impactos previstos en pacificación territorial y percepción de seguridad ciudadana no modelan rezagos temporales ni riesgos críticos como retaliaciones criminales, desplazamientos y captura institucional.",
+        "intervention": "Diseñar matriz de impactos y riesgos para pacificación territorial y percepción de seguridad ciudadana con escenarios probabilísticos, análisis de retaliaciones criminales, desplazamientos y captura institucional y planes de contingencia articulados al Comité de Orden Público y Sala de Análisis SAT.",
+        "indicator": {
+          "name": "PA02-DIM05 impactos con riesgos modelados",
+          "baseline": null,
+          "target": 0.7,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Gobierno Municipal",
+          "role": "coordina seguridad y convivencia",
+          "partners": [
+            "Policía Nacional",
+            "Unidad de Derechos Humanos",
+            "Alto Consejero para la Seguridad"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T3"
+        },
+        "verification": [
+          "Matriz de impactos y riesgos de pacificación territorial y percepción de seguridad ciudadana",
+          "Escenarios contrafactuales validados por el Comité de Orden Público y Sala de Análisis SAT",
+          "Acta del comité de gestión del riesgo"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA02-DIM06-DAG",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA02",
+        "dim_id": "DIM06",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q056}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: no existe DAG causal que ordene prevención situacional, control policial y justicia restaurativa ni explicite moderadores como capacidad de fuerza pública y cooperación comunitaria.",
+        "intervention": "Elaborar y validar un DAG para prevención situacional, control policial y justicia restaurativa con nodos de insumo a impacto, supuestos explícitos, moderadores (capacidad de fuerza pública y cooperación comunitaria) y bitácora de pruebas de consistencia.",
+        "indicator": {
+          "name": "PA02-DIM06 DAG validado",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Gobierno Municipal",
+          "role": "coordina seguridad y convivencia",
+          "partners": [
+            "Policía Nacional",
+            "Unidad de Derechos Humanos",
+            "Alto Consejero para la Seguridad"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "DAG validado para prevención situacional, control policial y justicia restaurativa",
+          "Bitácora de supuestos y versiones firmada",
+          "Informe de revisión externa de coherencia causal"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA03-DIM01-LB01",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA03",
+        "dim_id": "DIM01",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q061}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: el diagnóstico no consolida línea base cuantitativa y series verificables sobre amenazas ambientales, gestión del riesgo y degradación ecosistémica, ni documenta fuentes acreditadas y supuestos de validez.",
+        "intervention": "Levantar y normalizar las líneas base de amenazas ambientales, gestión del riesgo y degradación ecosistémica integrando registros de IDEAM, SINA y Consejo Municipal de Gestión del Riesgo en el Sistema de Información Ambiental y de Gestión del Riesgo, con metadatos de cobertura, periodicidad y responsable homologados con Planeación y Hacienda.",
+        "indicator": {
+          "name": "PA03-DIM01 líneas base homologadas",
+          "baseline": null,
+          "target": 0.85,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Ambiente y Gestión del Riesgo",
+          "role": "coordina política ambiental y PMGRD",
+          "partners": [
+            "Corporación Autónoma Regional",
+            "Oficina de Gestión del Riesgo",
+            "Secretaría de Hacienda"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Ficha técnica de línea base sobre amenazas ambientales, gestión del riesgo y degradación ecosistémica",
+          "Sistema de Información Ambiental y de Gestión del Riesgo con metadatos aprobados",
+          "Acta del comité técnico intersectorial de datos"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA03-DIM02-ACT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA03",
+        "dim_id": "DIM02",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q066}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: las actividades priorizadas no describen el instrumento denominado planes de manejo ambiental y estrategias de gestión del riesgo con población comunidades en áreas de amenaza y sectores productivos, dosis y lógica causal para lograr reducción de vulnerabilidad y mitigación de riesgos.",
+        "intervention": "Documentar el portafolio de actividades del instrumento planes de manejo ambiental y estrategias de gestión del riesgo en fichas operativas con objetivo causal, población objetivo, dosis (simulacros semestrales y asistencia técnica mensual), costos y responsables, integradas al sistema SIGAM y plataforma PMGRD y validadas con Planeación.",
+        "indicator": {
+          "name": "PA03-DIM02 actividades con ficha completa",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Ambiente y Gestión del Riesgo",
+          "role": "coordina política ambiental y PMGRD",
+          "partners": [
+            "Corporación Autónoma Regional",
+            "Oficina de Gestión del Riesgo",
+            "Secretaría de Hacienda"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Fichas operativas del instrumento planes de manejo ambiental y estrategias de gestión del riesgo",
+          "Reporte del SIGAM y plataforma PMGRD",
+          "Acta de comité operativo intersectorial"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA03-DIM03-BPIN",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA03",
+        "dim_id": "DIM03",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q071}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los productos priorizados carecen de ficha BPIN para obras de mitigación, sistemas de alerta temprana y restauración ecológica, sin línea base, meta y fuentes de verificación trazables.",
+        "intervention": "Radicar y validar las fichas BPIN de obras de mitigación, sistemas de alerta temprana y restauración ecológica con trazabilidad presupuestal (BPIN, SGR y recursos de adaptación climática), responsables definidos y articulación al Plan Plurianual de Inversiones.",
+        "indicator": {
+          "name": "PA03-DIM03 productos con BPIN y FV",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Ambiente y Gestión del Riesgo",
+          "role": "coordina política ambiental y PMGRD",
+          "partners": [
+            "Corporación Autónoma Regional",
+            "Oficina de Gestión del Riesgo",
+            "Secretaría de Hacienda"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Registro BPIN de obras de mitigación, sistemas de alerta temprana y restauración ecológica",
+          "Plan Plurianual de Inversiones con codificación BPIN",
+          "Concepto de viabilidad financiera suscrito"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA03-DIM04-RESULT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA03",
+        "dim_id": "DIM04",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q076}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los resultados esperados no enlazan los productos con disminución de pérdidas por desastres y mejora en servicios ecosistémicos ni justifican las metas bajo los supuestos de coordinación con Corporación Autónoma y gestión predial.",
+        "intervention": "Construir matriz producto-resultado que conecte entregables con disminución de pérdidas por desastres y mejora en servicios ecosistémicos, defina indicadores con línea base y metas, y documente supuestos de coordinación con Corporación Autónoma y gestión predial con responsables y cronograma.",
+        "indicator": {
+          "name": "PA03-DIM04 resultados con matriz válida",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Ambiente y Gestión del Riesgo",
+          "role": "coordina política ambiental y PMGRD",
+          "partners": [
+            "Corporación Autónoma Regional",
+            "Oficina de Gestión del Riesgo",
+            "Secretaría de Hacienda"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Matriz producto-resultado validada",
+          "Acta del comité de seguimiento y evaluación",
+          "Modelo de consistencia de metas para disminución de pérdidas por desastres y mejora en servicios ecosistémicos"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA03-DIM05-RIESGOS",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA03",
+        "dim_id": "DIM05",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q081}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los impactos previstos en resiliencia climática y reducción de riesgo sistémico no modelan rezagos temporales ni riesgos críticos como fenómenos extremos, invasión de rondas y debilidad institucional.",
+        "intervention": "Diseñar matriz de impactos y riesgos para resiliencia climática y reducción de riesgo sistémico con escenarios probabilísticos, análisis de fenómenos extremos, invasión de rondas y debilidad institucional y planes de contingencia articulados al Consejo Municipal de Gestión del Riesgo.",
+        "indicator": {
+          "name": "PA03-DIM05 impactos con riesgos modelados",
+          "baseline": null,
+          "target": 0.7,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Ambiente y Gestión del Riesgo",
+          "role": "coordina política ambiental y PMGRD",
+          "partners": [
+            "Corporación Autónoma Regional",
+            "Oficina de Gestión del Riesgo",
+            "Secretaría de Hacienda"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T3"
+        },
+        "verification": [
+          "Matriz de impactos y riesgos de resiliencia climática y reducción de riesgo sistémico",
+          "Escenarios contrafactuales validados por el Consejo Municipal de Gestión del Riesgo",
+          "Acta del comité de gestión del riesgo"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA03-DIM06-DAG",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA03",
+        "dim_id": "DIM06",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q086}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: no existe DAG causal que ordene ordenamiento ecológico, mitigación y recuperación postdesastre ni explicite moderadores como financiación del SGR y gobernanza comunitaria.",
+        "intervention": "Elaborar y validar un DAG para ordenamiento ecológico, mitigación y recuperación postdesastre con nodos de insumo a impacto, supuestos explícitos, moderadores (financiación del SGR y gobernanza comunitaria) y bitácora de pruebas de consistencia.",
+        "indicator": {
+          "name": "PA03-DIM06 DAG validado",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Ambiente y Gestión del Riesgo",
+          "role": "coordina política ambiental y PMGRD",
+          "partners": [
+            "Corporación Autónoma Regional",
+            "Oficina de Gestión del Riesgo",
+            "Secretaría de Hacienda"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "DAG validado para ordenamiento ecológico, mitigación y recuperación postdesastre",
+          "Bitácora de supuestos y versiones firmada",
+          "Informe de revisión externa de coherencia causal"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA04-DIM01-LB01",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA04",
+        "dim_id": "DIM01",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q091}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: el diagnóstico no consolida línea base cuantitativa y series verificables sobre cobertura y calidad en salud, educación y agua potable, ni documenta fuentes acreditadas y supuestos de validez.",
+        "intervention": "Levantar y normalizar las líneas base de cobertura y calidad en salud, educación y agua potable integrando registros de SISPRO, SIMAT y SUI en el Observatorio de DESC municipal, con metadatos de cobertura, periodicidad y responsable homologados con Planeación y Hacienda.",
+        "indicator": {
+          "name": "PA04-DIM01 líneas base homologadas",
+          "baseline": null,
+          "target": 0.85,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Planeación Social",
+          "role": "coordina programas DESC",
+          "partners": [
+            "Secretaría de Salud",
+            "Secretaría de Educación",
+            "Secretaría de Planeación"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Ficha técnica de línea base sobre cobertura y calidad en salud, educación y agua potable",
+          "Observatorio de DESC municipal con metadatos aprobados",
+          "Acta del comité técnico intersectorial de datos"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA04-DIM02-ACT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA04",
+        "dim_id": "DIM02",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q096}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: las actividades priorizadas no describen el instrumento denominado plan integral de mejoramiento de servicios sociales con población hogares vulnerables, estudiantes y pacientes priorizados, dosis y lógica causal para lograr cierre de brechas de acceso a servicios básicos.",
+        "intervention": "Documentar el portafolio de actividades del instrumento plan integral de mejoramiento de servicios sociales en fichas operativas con objetivo causal, población objetivo, dosis (microplanes trimestrales con metas de cobertura), costos y responsables, integradas al sistema SIGOB social y tableros de seguimiento sectorial y validadas con Planeación.",
+        "indicator": {
+          "name": "PA04-DIM02 actividades con ficha completa",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Planeación Social",
+          "role": "coordina programas DESC",
+          "partners": [
+            "Secretaría de Salud",
+            "Secretaría de Educación",
+            "Secretaría de Planeación"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Fichas operativas del instrumento plan integral de mejoramiento de servicios sociales",
+          "Reporte del SIGOB social y tableros de seguimiento sectorial",
+          "Acta de comité operativo intersectorial"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA04-DIM03-BPIN",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA04",
+        "dim_id": "DIM03",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q101}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los productos priorizados carecen de ficha BPIN para infraestructura educativa y sanitaria, redes de acueducto, sin línea base, meta y fuentes de verificación trazables.",
+        "intervention": "Radicar y validar las fichas BPIN de infraestructura educativa y sanitaria, redes de acueducto con trazabilidad presupuestal (BPIN, SGP y convenios sectoriales), responsables definidos y articulación al Plan Plurianual de Inversiones.",
+        "indicator": {
+          "name": "PA04-DIM03 productos con BPIN y FV",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Planeación Social",
+          "role": "coordina programas DESC",
+          "partners": [
+            "Secretaría de Salud",
+            "Secretaría de Educación",
+            "Secretaría de Planeación"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Registro BPIN de infraestructura educativa y sanitaria, redes de acueducto",
+          "Plan Plurianual de Inversiones con codificación BPIN",
+          "Concepto de viabilidad financiera suscrito"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA04-DIM04-RESULT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA04",
+        "dim_id": "DIM04",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q106}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los resultados esperados no enlazan los productos con mejoras en calidad educativa, salud preventiva y acceso a agua segura ni justifican las metas bajo los supuestos de coordinación con EPS, instituciones educativas y operadores de agua.",
+        "intervention": "Construir matriz producto-resultado que conecte entregables con mejoras en calidad educativa, salud preventiva y acceso a agua segura, defina indicadores con línea base y metas, y documente supuestos de coordinación con EPS, instituciones educativas y operadores de agua con responsables y cronograma.",
+        "indicator": {
+          "name": "PA04-DIM04 resultados con matriz válida",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Planeación Social",
+          "role": "coordina programas DESC",
+          "partners": [
+            "Secretaría de Salud",
+            "Secretaría de Educación",
+            "Secretaría de Planeación"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Matriz producto-resultado validada",
+          "Acta del comité de seguimiento y evaluación",
+          "Modelo de consistencia de metas para mejoras en calidad educativa, salud preventiva y acceso a agua segura"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA04-DIM05-RIESGOS",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA04",
+        "dim_id": "DIM05",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q111}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los impactos previstos en reducción de brechas DESC y riesgos sanitarios no modelan rezagos temporales ni riesgos críticos como brotes epidemiológicos, deserción y fallas de infraestructura.",
+        "intervention": "Diseñar matriz de impactos y riesgos para reducción de brechas DESC y riesgos sanitarios con escenarios probabilísticos, análisis de brotes epidemiológicos, deserción y fallas de infraestructura y planes de contingencia articulados al Comité de DESC y sala SITREP en salud pública.",
+        "indicator": {
+          "name": "PA04-DIM05 impactos con riesgos modelados",
+          "baseline": null,
+          "target": 0.7,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Planeación Social",
+          "role": "coordina programas DESC",
+          "partners": [
+            "Secretaría de Salud",
+            "Secretaría de Educación",
+            "Secretaría de Planeación"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T3"
+        },
+        "verification": [
+          "Matriz de impactos y riesgos de reducción de brechas DESC y riesgos sanitarios",
+          "Escenarios contrafactuales validados por el Comité de DESC y sala SITREP en salud pública",
+          "Acta del comité de gestión del riesgo"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA04-DIM06-DAG",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA04",
+        "dim_id": "DIM06",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q116}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: no existe DAG causal que ordene inversiones en infraestructura, talento humano y resultados sociales ni explicite moderadores como finanzas sectoriales y participación comunitaria.",
+        "intervention": "Elaborar y validar un DAG para inversiones en infraestructura, talento humano y resultados sociales con nodos de insumo a impacto, supuestos explícitos, moderadores (finanzas sectoriales y participación comunitaria) y bitácora de pruebas de consistencia.",
+        "indicator": {
+          "name": "PA04-DIM06 DAG validado",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Planeación Social",
+          "role": "coordina programas DESC",
+          "partners": [
+            "Secretaría de Salud",
+            "Secretaría de Educación",
+            "Secretaría de Planeación"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "DAG validado para inversiones en infraestructura, talento humano y resultados sociales",
+          "Bitácora de supuestos y versiones firmada",
+          "Informe de revisión externa de coherencia causal"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA05-DIM01-LB01",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA05",
+        "dim_id": "DIM01",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q121}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: el diagnóstico no consolida línea base cuantitativa y series verificables sobre registro de víctimas, retornos y reparación integral, ni documenta fuentes acreditadas y supuestos de validez.",
+        "intervention": "Levantar y normalizar las líneas base de registro de víctimas, retornos y reparación integral integrando registros de RUV, UARIV y comités de justicia transicional en el Sistema Municipal de Atención a Víctimas, con metadatos de cobertura, periodicidad y responsable homologados con Planeación y Hacienda.",
+        "indicator": {
+          "name": "PA05-DIM01 líneas base homologadas",
+          "baseline": null,
+          "target": 0.85,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Enlace Municipal de Víctimas",
+          "role": "coordina la política pública de víctimas",
+          "partners": [
+            "UARIV Territorial",
+            "Secretaría de Planeación",
+            "Personería Municipal"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Ficha técnica de línea base sobre registro de víctimas, retornos y reparación integral",
+          "Sistema Municipal de Atención a Víctimas con metadatos aprobados",
+          "Acta del comité técnico intersectorial de datos"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA05-DIM02-ACT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA05",
+        "dim_id": "DIM02",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q126}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: las actividades priorizadas no describen el instrumento denominado plan de atención, asistencia y reparación integral con población hogares víctimas, líderes y sujetos de reparación colectiva, dosis y lógica causal para lograr superar rezagos en reparación y garantía de derechos.",
+        "intervention": "Documentar el portafolio de actividades del instrumento plan de atención, asistencia y reparación integral en fichas operativas con objetivo causal, población objetivo, dosis (rutas de atención personalizadas con seguimiento bimestral), costos y responsables, integradas al sistema SIAV y tablero de compromisos del PAPSIVI y validadas con Planeación.",
+        "indicator": {
+          "name": "PA05-DIM02 actividades con ficha completa",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Enlace Municipal de Víctimas",
+          "role": "coordina la política pública de víctimas",
+          "partners": [
+            "UARIV Territorial",
+            "Secretaría de Planeación",
+            "Personería Municipal"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Fichas operativas del instrumento plan de atención, asistencia y reparación integral",
+          "Reporte del SIAV y tablero de compromisos del PAPSIVI",
+          "Acta de comité operativo intersectorial"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA05-DIM03-BPIN",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA05",
+        "dim_id": "DIM03",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q131}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los productos priorizados carecen de ficha BPIN para centros regionales de atención, proyectos productivos y medidas de satisfacción, sin línea base, meta y fuentes de verificación trazables.",
+        "intervention": "Radicar y validar las fichas BPIN de centros regionales de atención, proyectos productivos y medidas de satisfacción con trazabilidad presupuestal (BPIN, Fondo de Reparación y recursos territoriales), responsables definidos y articulación al Plan Plurianual de Inversiones.",
+        "indicator": {
+          "name": "PA05-DIM03 productos con BPIN y FV",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Enlace Municipal de Víctimas",
+          "role": "coordina la política pública de víctimas",
+          "partners": [
+            "UARIV Territorial",
+            "Secretaría de Planeación",
+            "Personería Municipal"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Registro BPIN de centros regionales de atención, proyectos productivos y medidas de satisfacción",
+          "Plan Plurianual de Inversiones con codificación BPIN",
+          "Concepto de viabilidad financiera suscrito"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA05-DIM04-RESULT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA05",
+        "dim_id": "DIM04",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q136}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los resultados esperados no enlazan los productos con avances en reparación integral, retorno sostenible y no repetición ni justifican las metas bajo los supuestos de coordinación con UARIV, Ministerio del Interior y cooperación.",
+        "intervention": "Construir matriz producto-resultado que conecte entregables con avances en reparación integral, retorno sostenible y no repetición, defina indicadores con línea base y metas, y documente supuestos de coordinación con UARIV, Ministerio del Interior y cooperación con responsables y cronograma.",
+        "indicator": {
+          "name": "PA05-DIM04 resultados con matriz válida",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Enlace Municipal de Víctimas",
+          "role": "coordina la política pública de víctimas",
+          "partners": [
+            "UARIV Territorial",
+            "Secretaría de Planeación",
+            "Personería Municipal"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Matriz producto-resultado validada",
+          "Acta del comité de seguimiento y evaluación",
+          "Modelo de consistencia de metas para avances en reparación integral, retorno sostenible y no repetición"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA05-DIM05-RIESGOS",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA05",
+        "dim_id": "DIM05",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q141}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los impactos previstos en restitución de derechos y reconstrucción del tejido social no modelan rezagos temporales ni riesgos críticos como revictimización, amenazas y desfinanciamiento.",
+        "intervention": "Diseñar matriz de impactos y riesgos para restitución de derechos y reconstrucción del tejido social con escenarios probabilísticos, análisis de revictimización, amenazas y desfinanciamiento y planes de contingencia articulados al Comité de Justicia Transicional.",
+        "indicator": {
+          "name": "PA05-DIM05 impactos con riesgos modelados",
+          "baseline": null,
+          "target": 0.7,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Enlace Municipal de Víctimas",
+          "role": "coordina la política pública de víctimas",
+          "partners": [
+            "UARIV Territorial",
+            "Secretaría de Planeación",
+            "Personería Municipal"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T3"
+        },
+        "verification": [
+          "Matriz de impactos y riesgos de restitución de derechos y reconstrucción del tejido social",
+          "Escenarios contrafactuales validados por el Comité de Justicia Transicional",
+          "Acta del comité de gestión del riesgo"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA05-DIM06-DAG",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA05",
+        "dim_id": "DIM06",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q146}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: no existe DAG causal que ordene asistencia, reparación y garantías de no repetición articuladas ni explicite moderadores como seguridad en territorios y disponibilidad presupuestal.",
+        "intervention": "Elaborar y validar un DAG para asistencia, reparación y garantías de no repetición articuladas con nodos de insumo a impacto, supuestos explícitos, moderadores (seguridad en territorios y disponibilidad presupuestal) y bitácora de pruebas de consistencia.",
+        "indicator": {
+          "name": "PA05-DIM06 DAG validado",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Enlace Municipal de Víctimas",
+          "role": "coordina la política pública de víctimas",
+          "partners": [
+            "UARIV Territorial",
+            "Secretaría de Planeación",
+            "Personería Municipal"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "DAG validado para asistencia, reparación y garantías de no repetición articuladas",
+          "Bitácora de supuestos y versiones firmada",
+          "Informe de revisión externa de coherencia causal"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA06-DIM01-LB01",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA06",
+        "dim_id": "DIM01",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q151}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: el diagnóstico no consolida línea base cuantitativa y series verificables sobre nutrición, protección y educación de niños, niñas y adolescentes, ni documenta fuentes acreditadas y supuestos de validez.",
+        "intervention": "Levantar y normalizar las líneas base de nutrición, protección y educación de niños, niñas y adolescentes integrando registros de SISBEN, SIRITI, SIMAT e ICBF en el Observatorio de Infancia y Adolescencia, con metadatos de cobertura, periodicidad y responsable homologados con Planeación y Hacienda.",
+        "indicator": {
+          "name": "PA06-DIM01 líneas base homologadas",
+          "baseline": null,
+          "target": 0.85,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Desarrollo Social",
+          "role": "coordina política de infancia y juventud",
+          "partners": [
+            "ICBF Territorial",
+            "Secretaría de Educación",
+            "Secretaría de Salud"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Ficha técnica de línea base sobre nutrición, protección y educación de niños, niñas y adolescentes",
+          "Observatorio de Infancia y Adolescencia con metadatos aprobados",
+          "Acta del comité técnico intersectorial de datos"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA06-DIM02-ACT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA06",
+        "dim_id": "DIM02",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q156}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: las actividades priorizadas no describen el instrumento denominado programa integral para el desarrollo de niñez y juventud con población niños, niñas y adolescentes con enfoque diferencial, dosis y lógica causal para lograr mejorar protección, educación y nutrición infantil.",
+        "intervention": "Documentar el portafolio de actividades del instrumento programa integral para el desarrollo de niñez y juventud en fichas operativas con objetivo causal, población objetivo, dosis (sesiones semanales con seguimiento trimestral), costos y responsables, integradas al sistema SIMAT-ICBF y tablero de primera infancia y validadas con Planeación.",
+        "indicator": {
+          "name": "PA06-DIM02 actividades con ficha completa",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Desarrollo Social",
+          "role": "coordina política de infancia y juventud",
+          "partners": [
+            "ICBF Territorial",
+            "Secretaría de Educación",
+            "Secretaría de Salud"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Fichas operativas del instrumento programa integral para el desarrollo de niñez y juventud",
+          "Reporte del SIMAT-ICBF y tablero de primera infancia",
+          "Acta de comité operativo intersectorial"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA06-DIM03-BPIN",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA06",
+        "dim_id": "DIM03",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q161}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los productos priorizados carecen de ficha BPIN para centros de desarrollo infantil, entornos protectores y rutas de restablecimiento, sin línea base, meta y fuentes de verificación trazables.",
+        "intervention": "Radicar y validar las fichas BPIN de centros de desarrollo infantil, entornos protectores y rutas de restablecimiento con trazabilidad presupuestal (BPIN, recursos ICBF y SGP Infancia), responsables definidos y articulación al Plan Plurianual de Inversiones.",
+        "indicator": {
+          "name": "PA06-DIM03 productos con BPIN y FV",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Desarrollo Social",
+          "role": "coordina política de infancia y juventud",
+          "partners": [
+            "ICBF Territorial",
+            "Secretaría de Educación",
+            "Secretaría de Salud"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Registro BPIN de centros de desarrollo infantil, entornos protectores y rutas de restablecimiento",
+          "Plan Plurianual de Inversiones con codificación BPIN",
+          "Concepto de viabilidad financiera suscrito"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA06-DIM04-RESULT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA06",
+        "dim_id": "DIM04",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q166}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los resultados esperados no enlazan los productos con incremento en desarrollo integral y permanencia escolar ni justifican las metas bajo los supuestos de articulación con ICBF, MEN y sector salud.",
+        "intervention": "Construir matriz producto-resultado que conecte entregables con incremento en desarrollo integral y permanencia escolar, defina indicadores con línea base y metas, y documente supuestos de articulación con ICBF, MEN y sector salud con responsables y cronograma.",
+        "indicator": {
+          "name": "PA06-DIM04 resultados con matriz válida",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Desarrollo Social",
+          "role": "coordina política de infancia y juventud",
+          "partners": [
+            "ICBF Territorial",
+            "Secretaría de Educación",
+            "Secretaría de Salud"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Matriz producto-resultado validada",
+          "Acta del comité de seguimiento y evaluación",
+          "Modelo de consistencia de metas para incremento en desarrollo integral y permanencia escolar"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA06-DIM05-RIESGOS",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA06",
+        "dim_id": "DIM05",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q171}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los impactos previstos en reducción de vulnerabilidades y riesgos en el ciclo vital no modelan rezagos temporales ni riesgos críticos como violencias, trabajo infantil y desnutrición.",
+        "intervention": "Diseñar matriz de impactos y riesgos para reducción de vulnerabilidades y riesgos en el ciclo vital con escenarios probabilísticos, análisis de violencias, trabajo infantil y desnutrición y planes de contingencia articulados al Comité de Infancia y Adolescencia.",
+        "indicator": {
+          "name": "PA06-DIM05 impactos con riesgos modelados",
+          "baseline": null,
+          "target": 0.7,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Desarrollo Social",
+          "role": "coordina política de infancia y juventud",
+          "partners": [
+            "ICBF Territorial",
+            "Secretaría de Educación",
+            "Secretaría de Salud"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T3"
+        },
+        "verification": [
+          "Matriz de impactos y riesgos de reducción de vulnerabilidades y riesgos en el ciclo vital",
+          "Escenarios contrafactuales validados por el Comité de Infancia y Adolescencia",
+          "Acta del comité de gestión del riesgo"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA06-DIM06-DAG",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA06",
+        "dim_id": "DIM06",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q176}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: no existe DAG causal que ordene protección integral articulada con salud, educación y participación juvenil ni explicite moderadores como cobertura de talento humano especializado y participación familiar.",
+        "intervention": "Elaborar y validar un DAG para protección integral articulada con salud, educación y participación juvenil con nodos de insumo a impacto, supuestos explícitos, moderadores (cobertura de talento humano especializado y participación familiar) y bitácora de pruebas de consistencia.",
+        "indicator": {
+          "name": "PA06-DIM06 DAG validado",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Desarrollo Social",
+          "role": "coordina política de infancia y juventud",
+          "partners": [
+            "ICBF Territorial",
+            "Secretaría de Educación",
+            "Secretaría de Salud"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "DAG validado para protección integral articulada con salud, educación y participación juvenil",
+          "Bitácora de supuestos y versiones firmada",
+          "Informe de revisión externa de coherencia causal"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA07-DIM01-LB01",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA07",
+        "dim_id": "DIM01",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q181}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: el diagnóstico no consolida línea base cuantitativa y series verificables sobre catastro multipropósito, uso del suelo y brechas rurales, ni documenta fuentes acreditadas y supuestos de validez.",
+        "intervention": "Levantar y normalizar las líneas base de catastro multipropósito, uso del suelo y brechas rurales integrando registros de IGAC, UPRA y POT vigente en el Sistema de Información Geográfica del POT, con metadatos de cobertura, periodicidad y responsable homologados con Planeación y Hacienda.",
+        "indicator": {
+          "name": "PA07-DIM01 líneas base homologadas",
+          "baseline": null,
+          "target": 0.85,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Planeación Territorial",
+          "role": "lidera ordenamiento y desarrollo rural",
+          "partners": [
+            "Secretaría de Infraestructura",
+            "Agencia de Desarrollo Rural",
+            "Secretaría de Agricultura"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Ficha técnica de línea base sobre catastro multipropósito, uso del suelo y brechas rurales",
+          "Sistema de Información Geográfica del POT con metadatos aprobados",
+          "Acta del comité técnico intersectorial de datos"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA07-DIM02-ACT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA07",
+        "dim_id": "DIM02",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q186}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: las actividades priorizadas no describen el instrumento denominado plan de ordenamiento rural y ejecución del POT con población productores rurales y comunidades campesinas, dosis y lógica causal para lograr ordenamiento del suelo y cierre de brechas rurales.",
+        "intervention": "Documentar el portafolio de actividades del instrumento plan de ordenamiento rural y ejecución del POT en fichas operativas con objetivo causal, población objetivo, dosis (asistencia técnica trimestral y formalización predial semestral), costos y responsables, integradas al sistema SIGOT y tablero POT y validadas con Planeación.",
+        "indicator": {
+          "name": "PA07-DIM02 actividades con ficha completa",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Planeación Territorial",
+          "role": "lidera ordenamiento y desarrollo rural",
+          "partners": [
+            "Secretaría de Infraestructura",
+            "Agencia de Desarrollo Rural",
+            "Secretaría de Agricultura"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Fichas operativas del instrumento plan de ordenamiento rural y ejecución del POT",
+          "Reporte del SIGOT y tablero POT",
+          "Acta de comité operativo intersectorial"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA07-DIM03-BPIN",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA07",
+        "dim_id": "DIM03",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q191}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los productos priorizados carecen de ficha BPIN para proyectos de vías terciarias, distritos de riego y formalización predial, sin línea base, meta y fuentes de verificación trazables.",
+        "intervention": "Radicar y validar las fichas BPIN de proyectos de vías terciarias, distritos de riego y formalización predial con trazabilidad presupuestal (BPIN, OCAD Paz y recursos de infraestructura), responsables definidos y articulación al Plan Plurianual de Inversiones.",
+        "indicator": {
+          "name": "PA07-DIM03 productos con BPIN y FV",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Planeación Territorial",
+          "role": "lidera ordenamiento y desarrollo rural",
+          "partners": [
+            "Secretaría de Infraestructura",
+            "Agencia de Desarrollo Rural",
+            "Secretaría de Agricultura"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Registro BPIN de proyectos de vías terciarias, distritos de riego y formalización predial",
+          "Plan Plurianual de Inversiones con codificación BPIN",
+          "Concepto de viabilidad financiera suscrito"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA07-DIM04-RESULT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA07",
+        "dim_id": "DIM04",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q196}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los resultados esperados no enlazan los productos con incremento en productividad rural y seguridad jurídica ni justifican las metas bajo los supuestos de coordinación con Agencia Nacional de Tierras y Ministerio de Transporte.",
+        "intervention": "Construir matriz producto-resultado que conecte entregables con incremento en productividad rural y seguridad jurídica, defina indicadores con línea base y metas, y documente supuestos de coordinación con Agencia Nacional de Tierras y Ministerio de Transporte con responsables y cronograma.",
+        "indicator": {
+          "name": "PA07-DIM04 resultados con matriz válida",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Planeación Territorial",
+          "role": "lidera ordenamiento y desarrollo rural",
+          "partners": [
+            "Secretaría de Infraestructura",
+            "Agencia de Desarrollo Rural",
+            "Secretaría de Agricultura"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Matriz producto-resultado validada",
+          "Acta del comité de seguimiento y evaluación",
+          "Modelo de consistencia de metas para incremento en productividad rural y seguridad jurídica"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA07-DIM05-RIESGOS",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA07",
+        "dim_id": "DIM05",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q201}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los impactos previstos en ordenamiento territorial y mitigación de conflictos por tierra no modelan rezagos temporales ni riesgos críticos como acaparamiento, conflictos sociales y variabilidad climática.",
+        "intervention": "Diseñar matriz de impactos y riesgos para ordenamiento territorial y mitigación de conflictos por tierra con escenarios probabilísticos, análisis de acaparamiento, conflictos sociales y variabilidad climática y planes de contingencia articulados al Consejo Territorial de Planeación y PMGRD rural.",
+        "indicator": {
+          "name": "PA07-DIM05 impactos con riesgos modelados",
+          "baseline": null,
+          "target": 0.7,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Planeación Territorial",
+          "role": "lidera ordenamiento y desarrollo rural",
+          "partners": [
+            "Secretaría de Infraestructura",
+            "Agencia de Desarrollo Rural",
+            "Secretaría de Agricultura"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T3"
+        },
+        "verification": [
+          "Matriz de impactos y riesgos de ordenamiento territorial y mitigación de conflictos por tierra",
+          "Escenarios contrafactuales validados por el Consejo Territorial de Planeación y PMGRD rural",
+          "Acta del comité de gestión del riesgo"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA07-DIM06-DAG",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA07",
+        "dim_id": "DIM06",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q206}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: no existe DAG causal que ordene infraestructura rural, servicios de apoyo y productividad ni explicite moderadores como articulación intersectorial y gobernanza campesina.",
+        "intervention": "Elaborar y validar un DAG para infraestructura rural, servicios de apoyo y productividad con nodos de insumo a impacto, supuestos explícitos, moderadores (articulación intersectorial y gobernanza campesina) y bitácora de pruebas de consistencia.",
+        "indicator": {
+          "name": "PA07-DIM06 DAG validado",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Planeación Territorial",
+          "role": "lidera ordenamiento y desarrollo rural",
+          "partners": [
+            "Secretaría de Infraestructura",
+            "Agencia de Desarrollo Rural",
+            "Secretaría de Agricultura"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "DAG validado para infraestructura rural, servicios de apoyo y productividad",
+          "Bitácora de supuestos y versiones firmada",
+          "Informe de revisión externa de coherencia causal"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA08-DIM01-LB01",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA08",
+        "dim_id": "DIM01",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q211}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: el diagnóstico no consolida línea base cuantitativa y series verificables sobre agresiones, amenazas y protección de líderes sociales, ni documenta fuentes acreditadas y supuestos de validez.",
+        "intervention": "Levantar y normalizar las líneas base de agresiones, amenazas y protección de líderes sociales integrando registros de SIPARES, UNP y Defensoría del Pueblo en el Sistema Municipal de Derechos Humanos, con metadatos de cobertura, periodicidad y responsable homologados con Planeación y Hacienda.",
+        "indicator": {
+          "name": "PA08-DIM01 líneas base homologadas",
+          "baseline": null,
+          "target": 0.85,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Oficina de Derechos Humanos Municipal",
+          "role": "coordina la política de garantías a líderes",
+          "partners": [
+            "Secretaría de Gobierno",
+            "Unidad Nacional de Protección",
+            "Personería"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Ficha técnica de línea base sobre agresiones, amenazas y protección de líderes sociales",
+          "Sistema Municipal de Derechos Humanos con metadatos aprobados",
+          "Acta del comité técnico intersectorial de datos"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA08-DIM02-ACT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA08",
+        "dim_id": "DIM02",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q216}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: las actividades priorizadas no describen el instrumento denominado plan integral de protección a líderes y defensores con población líderes sociales, defensores y organizaciones comunitarias, dosis y lógica causal para lograr reducción de agresiones y fortalecimiento de garantías.",
+        "intervention": "Documentar el portafolio de actividades del instrumento plan integral de protección a líderes y defensores en fichas operativas con objetivo causal, población objetivo, dosis (esquemas de protección con seguimiento mensual), costos y responsables, integradas al sistema SIPARES-DDHH y tableros de riesgo UNP y validadas con Planeación.",
+        "indicator": {
+          "name": "PA08-DIM02 actividades con ficha completa",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Oficina de Derechos Humanos Municipal",
+          "role": "coordina la política de garantías a líderes",
+          "partners": [
+            "Secretaría de Gobierno",
+            "Unidad Nacional de Protección",
+            "Personería"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Fichas operativas del instrumento plan integral de protección a líderes y defensores",
+          "Reporte del SIPARES-DDHH y tableros de riesgo UNP",
+          "Acta de comité operativo intersectorial"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA08-DIM03-BPIN",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA08",
+        "dim_id": "DIM03",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q221}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los productos priorizados carecen de ficha BPIN para esquemas de protección, refugios temporales y redes de autoprotección, sin línea base, meta y fuentes de verificación trazables.",
+        "intervention": "Radicar y validar las fichas BPIN de esquemas de protección, refugios temporales y redes de autoprotección con trazabilidad presupuestal (BPIN, recursos de seguridad y convenios con UNP), responsables definidos y articulación al Plan Plurianual de Inversiones.",
+        "indicator": {
+          "name": "PA08-DIM03 productos con BPIN y FV",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Oficina de Derechos Humanos Municipal",
+          "role": "coordina la política de garantías a líderes",
+          "partners": [
+            "Secretaría de Gobierno",
+            "Unidad Nacional de Protección",
+            "Personería"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Registro BPIN de esquemas de protección, refugios temporales y redes de autoprotección",
+          "Plan Plurianual de Inversiones con codificación BPIN",
+          "Concepto de viabilidad financiera suscrito"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA08-DIM04-RESULT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA08",
+        "dim_id": "DIM04",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q226}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los resultados esperados no enlazan los productos con disminución de amenazas y fortalecimiento organizativo ni justifican las metas bajo los supuestos de coordinación con Fiscalía, Policía y Procuraduría.",
+        "intervention": "Construir matriz producto-resultado que conecte entregables con disminución de amenazas y fortalecimiento organizativo, defina indicadores con línea base y metas, y documente supuestos de coordinación con Fiscalía, Policía y Procuraduría con responsables y cronograma.",
+        "indicator": {
+          "name": "PA08-DIM04 resultados con matriz válida",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Oficina de Derechos Humanos Municipal",
+          "role": "coordina la política de garantías a líderes",
+          "partners": [
+            "Secretaría de Gobierno",
+            "Unidad Nacional de Protección",
+            "Personería"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Matriz producto-resultado validada",
+          "Acta del comité de seguimiento y evaluación",
+          "Modelo de consistencia de metas para disminución de amenazas y fortalecimiento organizativo"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA08-DIM05-RIESGOS",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA08",
+        "dim_id": "DIM05",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q231}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los impactos previstos en garantías efectivas de derechos y liderazgo social no modelan rezagos temporales ni riesgos críticos como escalamiento de amenazas, estigmatización e impunidad.",
+        "intervention": "Diseñar matriz de impactos y riesgos para garantías efectivas de derechos y liderazgo social con escenarios probabilísticos, análisis de escalamiento de amenazas, estigmatización e impunidad y planes de contingencia articulados al Comité de Evaluación de Riesgo y Recomendación de Medidas.",
+        "indicator": {
+          "name": "PA08-DIM05 impactos con riesgos modelados",
+          "baseline": null,
+          "target": 0.7,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Oficina de Derechos Humanos Municipal",
+          "role": "coordina la política de garantías a líderes",
+          "partners": [
+            "Secretaría de Gobierno",
+            "Unidad Nacional de Protección",
+            "Personería"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T3"
+        },
+        "verification": [
+          "Matriz de impactos y riesgos de garantías efectivas de derechos y liderazgo social",
+          "Escenarios contrafactuales validados por el Comité de Evaluación de Riesgo y Recomendación de Medidas",
+          "Acta del comité de gestión del riesgo"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA08-DIM06-DAG",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA08",
+        "dim_id": "DIM06",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q236}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: no existe DAG causal que ordene prevención, protección, investigación y fortalecimiento comunitario ni explicite moderadores como respuesta judicial y confianza comunitaria.",
+        "intervention": "Elaborar y validar un DAG para prevención, protección, investigación y fortalecimiento comunitario con nodos de insumo a impacto, supuestos explícitos, moderadores (respuesta judicial y confianza comunitaria) y bitácora de pruebas de consistencia.",
+        "indicator": {
+          "name": "PA08-DIM06 DAG validado",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Oficina de Derechos Humanos Municipal",
+          "role": "coordina la política de garantías a líderes",
+          "partners": [
+            "Secretaría de Gobierno",
+            "Unidad Nacional de Protección",
+            "Personería"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "DAG validado para prevención, protección, investigación y fortalecimiento comunitario",
+          "Bitácora de supuestos y versiones firmada",
+          "Informe de revisión externa de coherencia causal"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA09-DIM01-LB01",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA09",
+        "dim_id": "DIM01",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q241}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: el diagnóstico no consolida línea base cuantitativa y series verificables sobre hacinamiento, salud y condiciones de establecimientos penitenciarios, ni documenta fuentes acreditadas y supuestos de validez.",
+        "intervention": "Levantar y normalizar las líneas base de hacinamiento, salud y condiciones de establecimientos penitenciarios integrando registros de INPEC, USPEC y Secretaría de Salud en el Sistema Municipal de Atención a PPL, con metadatos de cobertura, periodicidad y responsable homologados con Planeación y Hacienda.",
+        "indicator": {
+          "name": "PA09-DIM01 líneas base homologadas",
+          "baseline": null,
+          "target": 0.85,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Gobierno y Justicia",
+          "role": "lidera política penitenciaria territorial",
+          "partners": [
+            "INPEC Regional",
+            "Secretaría de Salud",
+            "Secretaría de Infraestructura",
+            "Secretaría de Hacienda"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Ficha técnica de línea base sobre hacinamiento, salud y condiciones de establecimientos penitenciarios",
+          "Sistema Municipal de Atención a PPL con metadatos aprobados",
+          "Acta del comité técnico intersectorial de datos"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA09-DIM02-ACT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA09",
+        "dim_id": "DIM02",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q246}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: las actividades priorizadas no describen el instrumento denominado plan integral de humanización carcelaria y ampliación de cupos con población personas privadas de la libertad y personal custodio, dosis y lógica causal para lograr disminución del hacinamiento y mejora de condiciones.",
+        "intervention": "Documentar el portafolio de actividades del instrumento plan integral de humanización carcelaria y ampliación de cupos en fichas operativas con objetivo causal, población objetivo, dosis (intervenciones semanales en salud y formación laboral), costos y responsables, integradas al sistema SISIPEC y tablero penitenciario y validadas con Planeación.",
+        "indicator": {
+          "name": "PA09-DIM02 actividades con ficha completa",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Gobierno y Justicia",
+          "role": "lidera política penitenciaria territorial",
+          "partners": [
+            "INPEC Regional",
+            "Secretaría de Salud",
+            "Secretaría de Infraestructura",
+            "Secretaría de Hacienda"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Fichas operativas del instrumento plan integral de humanización carcelaria y ampliación de cupos",
+          "Reporte del SISIPEC y tablero penitenciario",
+          "Acta de comité operativo intersectorial"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA09-DIM03-BPIN",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA09",
+        "dim_id": "DIM03",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q251}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los productos priorizados carecen de ficha BPIN para obras de infraestructura carcelaria, módulos de salud y talleres productivos, sin línea base, meta y fuentes de verificación trazables.",
+        "intervention": "Radicar y validar las fichas BPIN de obras de infraestructura carcelaria, módulos de salud y talleres productivos con trazabilidad presupuestal (BPIN, recursos USPEC y vigencias futuras municipales), responsables definidos y articulación al Plan Plurianual de Inversiones.",
+        "indicator": {
+          "name": "PA09-DIM03 productos con BPIN y FV",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Gobierno y Justicia",
+          "role": "lidera política penitenciaria territorial",
+          "partners": [
+            "INPEC Regional",
+            "Secretaría de Salud",
+            "Secretaría de Infraestructura",
+            "Secretaría de Hacienda"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Registro BPIN de obras de infraestructura carcelaria, módulos de salud y talleres productivos",
+          "Plan Plurianual de Inversiones con codificación BPIN",
+          "Concepto de viabilidad financiera suscrito"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA09-DIM04-RESULT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA09",
+        "dim_id": "DIM04",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q256}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los resultados esperados no enlazan los productos con reducción de hacinamiento y mejora en indicadores de salud y reinserción ni justifican las metas bajo los supuestos de coordinación con INPEC, Ministerio de Justicia y sector salud.",
+        "intervention": "Construir matriz producto-resultado que conecte entregables con reducción de hacinamiento y mejora en indicadores de salud y reinserción, defina indicadores con línea base y metas, y documente supuestos de coordinación con INPEC, Ministerio de Justicia y sector salud con responsables y cronograma.",
+        "indicator": {
+          "name": "PA09-DIM04 resultados con matriz válida",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Gobierno y Justicia",
+          "role": "lidera política penitenciaria territorial",
+          "partners": [
+            "INPEC Regional",
+            "Secretaría de Salud",
+            "Secretaría de Infraestructura",
+            "Secretaría de Hacienda"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Matriz producto-resultado validada",
+          "Acta del comité de seguimiento y evaluación",
+          "Modelo de consistencia de metas para reducción de hacinamiento y mejora en indicadores de salud y reinserción"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA09-DIM05-RIESGOS",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA09",
+        "dim_id": "DIM05",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q261}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los impactos previstos en garantía de derechos y reducción de reincidencia no modelan rezagos temporales ni riesgos críticos como disturbios, fallas sanitarias y retrasos en obras.",
+        "intervention": "Diseñar matriz de impactos y riesgos para garantía de derechos y reducción de reincidencia con escenarios probabilísticos, análisis de disturbios, fallas sanitarias y retrasos en obras y planes de contingencia articulados al Comité de Seguimiento Penitenciario.",
+        "indicator": {
+          "name": "PA09-DIM05 impactos con riesgos modelados",
+          "baseline": null,
+          "target": 0.7,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Gobierno y Justicia",
+          "role": "lidera política penitenciaria territorial",
+          "partners": [
+            "INPEC Regional",
+            "Secretaría de Salud",
+            "Secretaría de Infraestructura",
+            "Secretaría de Hacienda"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T3"
+        },
+        "verification": [
+          "Matriz de impactos y riesgos de garantía de derechos y reducción de reincidencia",
+          "Escenarios contrafactuales validados por el Comité de Seguimiento Penitenciario",
+          "Acta del comité de gestión del riesgo"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA09-DIM06-DAG",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA09",
+        "dim_id": "DIM06",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q266}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: no existe DAG causal que ordene infraestructura, salud integral y programas de resocialización ni explicite moderadores como disponibilidad presupuestal y coordinación interinstitucional.",
+        "intervention": "Elaborar y validar un DAG para infraestructura, salud integral y programas de resocialización con nodos de insumo a impacto, supuestos explícitos, moderadores (disponibilidad presupuestal y coordinación interinstitucional) y bitácora de pruebas de consistencia.",
+        "indicator": {
+          "name": "PA09-DIM06 DAG validado",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Secretaría de Gobierno y Justicia",
+          "role": "lidera política penitenciaria territorial",
+          "partners": [
+            "INPEC Regional",
+            "Secretaría de Salud",
+            "Secretaría de Infraestructura",
+            "Secretaría de Hacienda"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "DAG validado para infraestructura, salud integral y programas de resocialización",
+          "Bitácora de supuestos y versiones firmada",
+          "Informe de revisión externa de coherencia causal"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA10-DIM01-LB01",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA10",
+        "dim_id": "DIM01",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q271}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: el diagnóstico no consolida línea base cuantitativa y series verificables sobre regularización, acceso a servicios y caracterización de población migrante, ni documenta fuentes acreditadas y supuestos de validez.",
+        "intervention": "Levantar y normalizar las líneas base de regularización, acceso a servicios y caracterización de población migrante integrando registros de Migración Colombia, SISBEN y Registro Único de Migrantes en el Observatorio Municipal de Población Migrante, con metadatos de cobertura, periodicidad y responsable homologados con Planeación y Hacienda.",
+        "indicator": {
+          "name": "PA10-DIM01 líneas base homologadas",
+          "baseline": null,
+          "target": 0.85,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Gerencia de Atención al Migrante",
+          "role": "coordina integración de población migrante",
+          "partners": [
+            "Migración Colombia",
+            "Secretaría de Gobierno",
+            "Secretaría de Integración Social"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Ficha técnica de línea base sobre regularización, acceso a servicios y caracterización de población migrante",
+          "Observatorio Municipal de Población Migrante con metadatos aprobados",
+          "Acta del comité técnico intersectorial de datos"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA10-DIM02-ACT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA10",
+        "dim_id": "DIM02",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q276}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: las actividades priorizadas no describen el instrumento denominado plan integral de integración socioeconómica de población migrante con población migrantes, refugiados y retornados asentados en el territorio, dosis y lógica causal para lograr incremento de regularización y acceso a servicios básicos.",
+        "intervention": "Documentar el portafolio de actividades del instrumento plan integral de integración socioeconómica de población migrante en fichas operativas con objetivo causal, población objetivo, dosis (jornadas bimestrales de regularización y servicios integrados), costos y responsables, integradas al sistema SIVIGILA migrante y tablero intersectorial de integración y validadas con Planeación.",
+        "indicator": {
+          "name": "PA10-DIM02 actividades con ficha completa",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Gerencia de Atención al Migrante",
+          "role": "coordina integración de población migrante",
+          "partners": [
+            "Migración Colombia",
+            "Secretaría de Gobierno",
+            "Secretaría de Integración Social"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T1"
+        },
+        "verification": [
+          "Fichas operativas del instrumento plan integral de integración socioeconómica de población migrante",
+          "Reporte del SIVIGILA migrante y tablero intersectorial de integración",
+          "Acta de comité operativo intersectorial"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA10-DIM03-BPIN",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA10",
+        "dim_id": "DIM03",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q281}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los productos priorizados carecen de ficha BPIN para centros integrados de atención, ventanillas únicas y programas de empleabilidad, sin línea base, meta y fuentes de verificación trazables.",
+        "intervention": "Radicar y validar las fichas BPIN de centros integrados de atención, ventanillas únicas y programas de empleabilidad con trazabilidad presupuestal (BPIN, cooperación internacional y recursos nacionales de integración), responsables definidos y articulación al Plan Plurianual de Inversiones.",
+        "indicator": {
+          "name": "PA10-DIM03 productos con BPIN y FV",
+          "baseline": null,
+          "target": 0.8,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Gerencia de Atención al Migrante",
+          "role": "coordina integración de población migrante",
+          "partners": [
+            "Migración Colombia",
+            "Secretaría de Gobierno",
+            "Secretaría de Integración Social"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Registro BPIN de centros integrados de atención, ventanillas únicas y programas de empleabilidad",
+          "Plan Plurianual de Inversiones con codificación BPIN",
+          "Concepto de viabilidad financiera suscrito"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA10-DIM04-RESULT",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA10",
+        "dim_id": "DIM04",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q286}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los resultados esperados no enlazan los productos con incremento en regularización, afiliación en salud y matrícula educativa ni justifican las metas bajo los supuestos de coordinación con MEN, Ministerio de Salud y cooperación internacional.",
+        "intervention": "Construir matriz producto-resultado que conecte entregables con incremento en regularización, afiliación en salud y matrícula educativa, defina indicadores con línea base y metas, y documente supuestos de coordinación con MEN, Ministerio de Salud y cooperación internacional con responsables y cronograma.",
+        "indicator": {
+          "name": "PA10-DIM04 resultados con matriz válida",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Gerencia de Atención al Migrante",
+          "role": "coordina integración de población migrante",
+          "partners": [
+            "Migración Colombia",
+            "Secretaría de Gobierno",
+            "Secretaría de Integración Social"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "Matriz producto-resultado validada",
+          "Acta del comité de seguimiento y evaluación",
+          "Modelo de consistencia de metas para incremento en regularización, afiliación en salud y matrícula educativa"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA10-DIM05-RIESGOS",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA10",
+        "dim_id": "DIM05",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q291}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: los impactos previstos en integración socioeconómica y reducción de xenofobia no modelan rezagos temporales ni riesgos críticos como cambios normativos, picos migratorios y tensiones sociales.",
+        "intervention": "Diseñar matriz de impactos y riesgos para integración socioeconómica y reducción de xenofobia con escenarios probabilísticos, análisis de cambios normativos, picos migratorios y tensiones sociales y planes de contingencia articulados al Comité Municipal de Migraciones.",
+        "indicator": {
+          "name": "PA10-DIM05 impactos con riesgos modelados",
+          "baseline": null,
+          "target": 0.7,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Gerencia de Atención al Migrante",
+          "role": "coordina integración de población migrante",
+          "partners": [
+            "Migración Colombia",
+            "Secretaría de Gobierno",
+            "Secretaría de Integración Social"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T3"
+        },
+        "verification": [
+          "Matriz de impactos y riesgos de integración socioeconómica y reducción de xenofobia",
+          "Escenarios contrafactuales validados por el Comité Municipal de Migraciones",
+          "Acta del comité de gestión del riesgo"
+        ]
+      }
+    },
+    {
+      "rule_id": "REC-MICRO-PA10-DIM06-DAG",
+      "level": "MICRO",
+      "when": {
+        "pa_id": "PA10",
+        "dim_id": "DIM06",
+        "score_lt": 1.65
+      },
+      "template": {
+        "problem": "La pregunta {{Q296}} de {{PAxx}} presenta déficit específico en {{DIMxx}}: no existe DAG causal que ordene regularización, inclusión en servicios y generación de ingresos ni explicite moderadores como capacidad institucional y cooperación internacional.",
+        "intervention": "Elaborar y validar un DAG para regularización, inclusión en servicios y generación de ingresos con nodos de insumo a impacto, supuestos explícitos, moderadores (capacidad institucional y cooperación internacional) y bitácora de pruebas de consistencia.",
+        "indicator": {
+          "name": "PA10-DIM06 DAG validado",
+          "baseline": null,
+          "target": 0.75,
+          "unit": "proporción"
+        },
+        "responsible": {
+          "entity": "Gerencia de Atención al Migrante",
+          "role": "coordina integración de población migrante",
+          "partners": [
+            "Migración Colombia",
+            "Secretaría de Gobierno",
+            "Secretaría de Integración Social"
+          ]
+        },
+        "horizon": {
+          "start": "T0",
+          "end": "T2"
+        },
+        "verification": [
+          "DAG validado para regularización, inclusión en servicios y generación de ingresos",
+          "Bitácora de supuestos y versiones firmada",
+          "Informe de revisión externa de coherencia causal"
+        ]
+      }
+    }
+  ]
+}

--- a/rules/recommendation_rules.schema.json
+++ b/rules/recommendation_rules.schema.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/recommendation_rules.schema.json",
+  "title": "Recommendation Rules Schema",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "rule_id": {
+            "type": "string",
+            "pattern": "^REC-MICRO-PA\\d{2}-DIM\\d{2}-[A-Z0-9-]{3,}$"
+          },
+          "level": {
+            "type": "string",
+            "const": "MICRO"
+          },
+          "when": {
+            "type": "object",
+            "properties": {
+              "pa_id": {
+                "type": "string",
+                "pattern": "^PA\\d{2}$"
+              },
+              "dim_id": {
+                "type": "string",
+                "pattern": "^DIM\\d{2}$"
+              },
+              "score_lt": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "pa_id",
+              "dim_id",
+              "score_lt"
+            ],
+            "additionalProperties": false
+          },
+          "template": {
+            "type": "object",
+            "properties": {
+              "problem": {
+                "type": "string"
+              },
+              "intervention": {
+                "type": "string"
+              },
+              "indicator": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "baseline": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "target": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  },
+                  "unit": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "baseline",
+                  "target",
+                  "unit"
+                ],
+                "additionalProperties": false
+              },
+              "responsible": {
+                "type": "object",
+                "properties": {
+                  "entity": {
+                    "type": "string"
+                  },
+                  "role": {
+                    "type": "string"
+                  },
+                  "partners": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1
+                  }
+                },
+                "required": [
+                  "entity",
+                  "role",
+                  "partners"
+                ],
+                "additionalProperties": false
+              },
+              "horizon": {
+                "type": "object",
+                "properties": {
+                  "start": {
+                    "type": "string",
+                    "enum": [
+                      "T0"
+                    ]
+                  },
+                  "end": {
+                    "type": "string",
+                    "enum": [
+                      "T1",
+                      "T2",
+                      "T3"
+                    ]
+                  }
+                },
+                "required": [
+                  "start",
+                  "end"
+                ],
+                "additionalProperties": false
+              },
+              "verification": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 3
+              }
+            },
+            "required": [
+              "problem",
+              "intervention",
+              "indicator",
+              "responsible",
+              "horizon",
+              "verification"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "rule_id",
+          "level",
+          "when",
+          "template"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "version",
+    "rules"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add micro-level recommendation rules covering every PA×DIM pair triggered by score_lt < 1.65
- provide a JSON schema for the recommendation rules (version 1.0) to support validation

## Testing
- python - <<'PY'
import json
from itertools import product
with open('config/recommendation_rules.json','r',encoding='utf-8') as f:
    data=json.load(f)
pa_set={f"PA{i:02d}" for i in range(1,11)}
dim_set={f"DIM0{i}" for i in range(1,7)}
covered={(r['when']['pa_id'],r['when']['dim_id']) for r in data['rules']}
assert len(data['rules'])==60
assert covered=={(pa,dim) for pa in pa_set for dim in dim_set}
assert all(r['when']['score_lt']==1.65 for r in data['rules'])
PY

------
https://chatgpt.com/codex/tasks/task_e_68fa712482108328b10da4efed67e846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added JSON Schema validation for recommendation rules, establishing standardized structure requirements, field definitions, and data constraints to ensure consistency and data integrity across recommendation objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->