### PR TITLE
Anchor segmentation output to canonical tuples

### DIFF
--- a/choreographer.py
+++ b/choreographer.py
@@ -227,7 +227,7 @@ class ExecutionChoreographer:
         # Initialize validation engine
         self.validation_engine = ValidationEngine()
         logger.info("✓ ValidationEngine initialized")
-        
+
         # Execution statistics
         self.stats = {
             "total_methods": 584,
@@ -1760,10 +1760,10 @@ class ExecutionChoreographer:
         """Get execution statistics"""
         integration_rate = (self.stats["methods_initialized"] / self.stats["total_methods"]) * 100
         success_rate = (
-            self.stats["successful_executions"] / 
+            self.stats["successful_executions"] /
             max(1, self.stats["successful_executions"] + self.stats["failed_executions"])
         ) * 100
-        
+
         return {
             "total_methods": self.stats["total_methods"],
             "integration_target": self.stats["integration_target"],
@@ -1773,7 +1773,6 @@ class ExecutionChoreographer:
             "failed_executions": self.stats["failed_executions"],
             "success_rate": f"{success_rate:.1f}%"
         }
-
 
 # ============================================================================
 # EXAMPLE USAGE
@@ -1804,14 +1803,21 @@ def example_usage():
     # Example plan document
     plan_document = """
     PLAN DE DESARROLLO MUNICIPAL 2024-2027
-    
+
     DIAGNÓSTICO TERRITORIAL
     La línea base cuantitativa indica que el municipio cuenta con 45,000 habitantes.
     La magnitud del problema se evidencia en una tasa de pobreza del 42.3%.
     Los recursos disponibles ascienden a $12,500 millones.
-    
+
     ESTRATEGIA DE INTERVENCIÓN
     Se implementarán programas de educación y salud.
+
+    PLANIFICACIÓN OPERATIVA
+    Las actividades incluyen tablas de cronograma con responsables y códigos BPIN.
+    Los productos tendrán indicadores con línea base, metas y fuentes de verificación.
+    Los resultados consideran supuestos críticos y rutas de aprendizaje adaptativo.
+    El impacto proyecta transformaciones estructurales con rutas de maduración.
+    La teoría de cambio plantea grafo causal completo con pilotos de validación.
     """
     
     plan_metadata = {
@@ -1839,7 +1845,7 @@ def example_usage():
         print(f"\nQualitative Note: {result.micro_answer.qualitative_note}")
         print(f"Quantitative Score: {result.micro_answer.quantitative_score:.2f}")
         print(f"Confidence: {result.micro_answer.confidence:.2f}")
-    
+
     # Print statistics
     stats = choreographer.get_statistics()
     print("\n" + "=" * 80)

--- a/schemas/question_segmentation.schema.json
+++ b/schemas/question_segmentation.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Canonical Question Segmentation Output",
+  "type": "object",
+  "required": ["metadata", "question_segments", "question_segment_index"],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "required": [
+        "questionnaire_version",
+        "rubric_version",
+        "total_contracts",
+        "covered_contracts",
+        "coverage_ratio",
+        "total_segments",
+        "input_sha256",
+        "contracts_sha256",
+        "segmentation_method"
+      ],
+      "properties": {
+        "questionnaire_version": {"type": ["string", "null"]},
+        "rubric_version": {"type": ["string", "null"]},
+        "total_contracts": {"type": "integer", "minimum": 0},
+        "covered_contracts": {"type": "integer", "minimum": 0},
+        "coverage_ratio": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+        "total_segments": {"type": "integer", "minimum": 0},
+        "input_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "contracts_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "segmentation_method": {"type": "string"}
+      },
+      "additionalProperties": true
+    },
+    "question_segments": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "legacy_question_id",
+          "policy_area_id",
+          "dimension_id",
+          "policy_area_legacy",
+          "dimension_legacy",
+          "question_number",
+          "question_template",
+          "scoring_modality",
+          "evidence_sources",
+          "contract_hash",
+          "evidence_manifest"
+        ],
+        "properties": {
+          "legacy_question_id": {"type": "string"},
+          "policy_area_id": {"type": "string"},
+          "dimension_id": {"type": "string"},
+          "policy_area_legacy": {"type": "string"},
+          "dimension_legacy": {"type": "string"},
+          "question_number": {"type": "integer"},
+          "question_template": {"type": "string"},
+          "scoring_modality": {"type": "string"},
+          "evidence_sources": {"type": ["object", "array"]},
+          "contract_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+          "evidence_manifest": {
+            "type": "object",
+            "required": [
+              "matched",
+              "matched_segment_count",
+              "expected_elements",
+              "search_patterns",
+              "verification_patterns",
+              "evaluation_criteria",
+              "pattern_hits",
+              "matched_segments",
+              "attestation"
+            ],
+            "properties": {
+              "matched": {"type": "boolean"},
+              "matched_segment_count": {"type": "integer", "minimum": 0},
+              "expected_elements": {"type": "array"},
+              "search_patterns": {"type": "object"},
+              "verification_patterns": {"type": "array"},
+              "evaluation_criteria": {"type": "object"},
+              "pattern_hits": {"type": "object"},
+              "matched_segments": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "segment_index",
+                    "segment_text",
+                    "segment_hash",
+                    "matched_patterns"
+                  ],
+                  "properties": {
+                    "segment_index": {"type": "integer", "minimum": 0},
+                    "segment_text": {"type": "string"},
+                    "segment_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+                    "matched_patterns": {"type": "array", "items": {"type": "string"}}
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "attestation": {
+                "type": "object",
+                "required": ["contract_sha256", "segment_hash_chain"],
+                "properties": {
+                  "contract_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+                  "segment_hash_chain": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "question_segment_index": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "key_tuple",
+          "canonical_question_id",
+          "policy_area_id",
+          "dimension_id",
+          "legacy_question_id",
+          "contract_hash",
+          "evidence_manifest"
+        ],
+        "properties": {
+          "key_tuple": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 3,
+            "maxItems": 3
+          },
+          "canonical_question_id": {"type": "string"},
+          "policy_area_id": {"type": "string"},
+          "dimension_id": {"type": "string"},
+          "legacy_question_id": {"type": "string"},
+          "contract_hash": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+          "evidence_manifest": {"$ref": "#/properties/question_segments/additionalProperties/properties/evidence_manifest"}
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_architecture_validator.py
+++ b/tests/test_architecture_validator.py
@@ -1,0 +1,26 @@
+"""Tests for the architecture validation utilities."""
+
+from pathlib import Path
+
+import pytest
+
+from validation import validate_architecture
+
+
+@pytest.fixture(scope="module")
+def architecture_paths() -> tuple[Path, Path]:
+    root = Path(__file__).resolve().parent.parent
+    return (
+        root / "policy_analysis_architecture.json",
+        root / "COMPLETE_METHOD_CLASS_MAP.json",
+    )
+
+
+def test_architecture_methods_are_resolvable(architecture_paths: tuple[Path, Path]) -> None:
+    spec_path, inventory_path = architecture_paths
+    result = validate_architecture(spec_path, inventory_path)
+
+    assert result.coverage > 0, "Coverage should be greater than zero."
+    assert not result.missing_methods, (
+        "Every method referenced in the architecture must exist in the codebase.",
+    )

--- a/tests/test_document_processor_segmenter.py
+++ b/tests/test_document_processor_segmenter.py
@@ -1,0 +1,144 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from Analyzer_one import DocumentProcessor, CanonicalQuestionSegmenter
+
+try:
+    import jsonschema
+except ImportError:  # pragma: no cover - jsonschema is an optional dependency
+    jsonschema = None
+
+
+def _serializable_payload(segmentation: dict) -> dict:
+    """Convert segmentation payload into JSON-serializable structure."""
+
+    question_segments = {
+        "|".join(key_tuple): payload
+        for key_tuple, payload in segmentation["question_segments"].items()
+    }
+
+    return {
+        "metadata": segmentation["metadata"],
+        "question_segments": question_segments,
+        "question_segment_index": segmentation["question_segment_index"],
+    }
+
+
+def test_canonical_contract_loading_ensures_schema_alignment():
+    contracts, questionnaire_meta, rubric_meta, contracts_hash = (
+        DocumentProcessor.load_canonical_question_contracts()
+    )
+
+    assert len(contracts) == 300
+    assert questionnaire_meta.get("version") is not None
+    assert rubric_meta.get("version") is not None
+    assert isinstance(contracts_hash, str) and len(contracts_hash) == 64
+
+    canonical_keys = {
+        (contract.canonical_question_id, contract.policy_area_id, contract.dimension_id)
+        for contract in contracts
+    }
+    assert len(canonical_keys) == len(contracts) == 300
+
+    first = contracts[0]
+    assert first.canonical_question_id == "Q001"
+    assert first.legacy_question_id.count("-") == 2
+    assert first.policy_area_id.startswith("PA")
+    assert first.dimension_id.startswith("DIM")
+    assert len(first.contract_hash) == 64
+    assert isinstance(first.expected_elements, list)
+    assert isinstance(first.search_patterns, dict)
+    assert isinstance(first.verification_patterns, list)
+
+
+@pytest.fixture(scope="module")
+def canonical_segmenter():
+    return CanonicalQuestionSegmenter()
+
+
+def test_segmenter_deterministic_and_attested(canonical_segmenter):
+    plan_text = """
+    PLAN DE DESARROLLO MUNICIPAL 2024-2027
+    El diagnóstico establece una línea base cuantitativa del 2023 con datos del DANE.
+    Se reporta un porcentaje del 42.5% y la fuente es la Encuesta Nacional.
+    """
+
+    first_run = canonical_segmenter.segment_plan(plan_text)
+    second_run = canonical_segmenter.segment_plan(plan_text)
+
+    assert first_run["metadata"] == second_run["metadata"]
+    assert first_run["question_segments"] == second_run["question_segments"]
+    assert first_run["question_segment_index"] == second_run["question_segment_index"]
+
+    metadata = first_run["metadata"]
+    expected_hash = hashlib.sha256(plan_text.encode("utf-8")).hexdigest()
+    assert metadata["input_sha256"] == expected_hash
+    assert metadata["contracts_sha256"] == canonical_segmenter.contracts_hash
+
+    assert 0 < metadata["coverage_ratio"] <= 1
+
+    expected_order = [
+        (
+            contract.canonical_question_id,
+            contract.policy_area_id,
+            contract.dimension_id,
+        )
+        for contract in canonical_segmenter.contracts
+    ]
+    assert list(first_run["question_segments"].keys()) == expected_order
+
+    matched_questions = [
+        segment for segment in first_run["question_segments"].values()
+        if segment["evidence_manifest"]["matched"]
+    ]
+    assert matched_questions, "Expected at least one matched question for sample plan"
+
+    for matched in matched_questions:
+        manifest = matched["evidence_manifest"]
+        assert manifest["matched_segment_count"] > 0
+        assert isinstance(manifest["expected_elements"], list)
+        assert isinstance(manifest["matched_segments"], list)
+        assert manifest["attestation"]["contract_sha256"] == matched["contract_hash"]
+        for segment in manifest["matched_segments"]:
+            assert len(segment["segment_hash"]) == 64
+            assert segment["matched_patterns"], "Matched segment should list patterns"
+
+    for index_entry in first_run["question_segment_index"]:
+        key_tuple = tuple(index_entry["key_tuple"])
+        assert key_tuple in first_run["question_segments"]
+        payload = first_run["question_segments"][key_tuple]
+        assert payload["contract_hash"] == index_entry["contract_hash"]
+        assert payload["evidence_manifest"] == index_entry["evidence_manifest"]
+
+    if jsonschema is not None:
+        schema_path = Path("schemas/question_segmentation.schema.json")
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+        jsonschema.validate(_serializable_payload(first_run), schema)
+
+
+def test_negative_control_zero_coverage(canonical_segmenter):
+    noise_plan = "Solo texto genérico sin patrones relevantes ni datos verificables."
+    segmentation = canonical_segmenter.segment_plan(noise_plan)
+
+    metadata = segmentation["metadata"]
+    assert metadata["coverage_ratio"] < 0.05
+    assert metadata["covered_contracts"] <= 15
+
+    sample_keys = list(segmentation["question_segments"].keys())[:5]
+    for key in sample_keys:
+        manifest = segmentation["question_segments"][key]["evidence_manifest"]
+        assert manifest["matched"] is False
+        assert manifest["matched_segment_count"] == 0
+        assert manifest["pattern_hits"] == {}
+
+    matched_entries = sum(
+        1 for entry in segmentation["question_segment_index"] if entry["evidence_manifest"]["matched"]
+    )
+    assert matched_entries == metadata["covered_contracts"]
+    if metadata["total_contracts"]:
+        assert pytest.approx(metadata["coverage_ratio"], rel=1e-6) == (
+            matched_entries / metadata["total_contracts"]
+        )

--- a/validation/__init__.py
+++ b/validation/__init__.py
@@ -1,8 +1,16 @@
 """Validation module for pre-execution checks and preconditions."""
 
+from .architecture_validator import (
+    ArchitectureValidationResult,
+    validate_architecture,
+    write_validation_report,
+)
 from .golden_rule import GoldenRuleValidator, GoldenRuleViolation
 
 __all__ = [
+    "ArchitectureValidationResult",
     "GoldenRuleValidator",
     "GoldenRuleViolation",
+    "validate_architecture",
+    "write_validation_report",
 ]

--- a/validation/architecture_validation_report.json
+++ b/validation/architecture_validation_report.json
@@ -1,0 +1,200 @@
+{
+  "coverage": 0.6296296296296297,
+  "total_spec_methods": 81,
+  "total_available_methods": 449,
+  "resolved_methods": [
+    "BayesianConfidenceCalculator.calculate_posterior",
+    "DocumentProcessor.load_docx",
+    "DocumentProcessor.load_pdf",
+    "IndustrialPolicyProcessor.__init__",
+    "IndustrialPolicyProcessor._build_point_patterns",
+    "IndustrialPolicyProcessor._compile_pattern_registry",
+    "IndustrialPolicyProcessor._match_patterns_in_sentences",
+    "IndustrialPolicyProcessor.process",
+    "MunicipalOntology.__init__",
+    "PDETMunicipalPlanAnalyzer._generate_recommendations",
+    "PDETMunicipalPlanAnalyzer.analyze_municipal_plan",
+    "PerformanceAnalyzer._calculate_loss_functions",
+    "PolicyAnalysisPipeline.__init__",
+    "PolicyContradictionDetector.__init__",
+    "PolicyContradictionDetector._build_knowledge_graph",
+    "PolicyContradictionDetector._calculate_confidence_interval",
+    "PolicyContradictionDetector._calculate_contradiction_entropy",
+    "PolicyContradictionDetector._calculate_global_semantic_coherence",
+    "PolicyContradictionDetector._calculate_graph_fragmentation",
+    "PolicyContradictionDetector._calculate_objective_alignment",
+    "PolicyContradictionDetector._calculate_syntactic_complexity",
+    "PolicyContradictionDetector._classify_contradiction",
+    "PolicyContradictionDetector._detect_logical_incompatibilities",
+    "PolicyContradictionDetector._detect_numerical_inconsistencies",
+    "PolicyContradictionDetector._detect_resource_conflicts",
+    "PolicyContradictionDetector._detect_temporal_conflicts",
+    "PolicyContradictionDetector._determine_relation_type",
+    "PolicyContradictionDetector._determine_semantic_role",
+    "PolicyContradictionDetector._extract_quantitative_claims",
+    "PolicyContradictionDetector._extract_resource_mentions",
+    "PolicyContradictionDetector._extract_temporal_markers",
+    "PolicyContradictionDetector._generate_embeddings",
+    "PolicyContradictionDetector._generate_resolution_recommendations",
+    "PolicyContradictionDetector._get_context_window",
+    "PolicyContradictionDetector._get_dependency_depth",
+    "PolicyContradictionDetector._get_graph_statistics",
+    "PolicyContradictionDetector._identify_affected_sections",
+    "PolicyContradictionDetector._identify_dependencies",
+    "PolicyContradictionDetector._initialize_pdm_patterns",
+    "PolicyContradictionDetector._parse_number",
+    "SemanticAnalyzer.__init__",
+    "SemanticAnalyzer._calculate_semantic_complexity",
+    "SemanticAnalyzer._classify_cross_cutting_themes",
+    "TemporalLogicVerifier._build_timeline",
+    "TemporalLogicVerifier._check_deadline_constraints",
+    "TemporalLogicVerifier._extract_resources",
+    "TemporalLogicVerifier.verify_temporal_consistency",
+    "TeoriaCambio._encontrar_caminos_completos",
+    "TeoriaCambio._validar_orden_causal",
+    "TeoriaCambio.validacion_completa",
+    "nx.DiGraph"
+  ],
+  "missing_methods": {},
+  "per_dimension": {
+    "D1": {
+      "D1-Q1": [
+        "IndustrialPolicyProcessor.process",
+        "PolicyContradictionDetector._extract_quantitative_claims",
+        "IndustrialPolicyProcessor._match_patterns_in_sentences",
+        "PolicyContradictionDetector._parse_number",
+        "SemanticAnalyzer._calculate_semantic_complexity",
+        "BayesianConfidenceCalculator.calculate_posterior"
+      ],
+      "D1-Q3": [
+        "PolicyContradictionDetector._extract_resource_mentions",
+        "PolicyContradictionDetector._detect_numerical_inconsistencies",
+        "PolicyContradictionDetector._detect_resource_conflicts"
+      ],
+      "D1-Q4": [
+        "IndustrialPolicyProcessor._match_patterns_in_sentences",
+        "PolicyContradictionDetector._determine_semantic_role",
+        "PolicyContradictionDetector._calculate_graph_fragmentation"
+      ],
+      "D1-Q5": [
+        "IndustrialPolicyProcessor._match_patterns_in_sentences",
+        "PolicyContradictionDetector._detect_temporal_conflicts",
+        "TemporalLogicVerifier.verify_temporal_consistency",
+        "PolicyContradictionDetector._calculate_confidence_interval"
+      ]
+    },
+    "D2": {
+      "D2-Q1": [
+        "PDETMunicipalPlanAnalyzer.analyze_municipal_plan",
+        "IndustrialPolicyProcessor._match_patterns_in_sentences",
+        "PolicyContradictionDetector._detect_temporal_conflicts",
+        "TemporalLogicVerifier._build_timeline"
+      ],
+      "D2-Q2_Q3": [
+        "IndustrialPolicyProcessor._match_patterns_in_sentences",
+        "PolicyContradictionDetector._determine_relation_type",
+        "SemanticAnalyzer._classify_cross_cutting_themes"
+      ],
+      "D2-Q4": [
+        "IndustrialPolicyProcessor._match_patterns_in_sentences",
+        "PolicyContradictionDetector._detect_logical_incompatibilities",
+        "PolicyContradictionDetector._identify_affected_sections"
+      ],
+      "D2-Q5": [
+        "PolicyContradictionDetector._calculate_global_semantic_coherence",
+        "PolicyContradictionDetector._build_knowledge_graph",
+        "PolicyContradictionDetector._get_dependency_depth"
+      ]
+    },
+    "D3": {
+      "D3-Q1": [
+        "PolicyContradictionDetector._extract_quantitative_claims",
+        "IndustrialPolicyProcessor._match_patterns_in_sentences",
+        "BayesianConfidenceCalculator.calculate_posterior"
+      ],
+      "D3-Q2": [
+        "PolicyContradictionDetector._detect_numerical_inconsistencies",
+        "PerformanceAnalyzer.analyze_loss_function"
+      ],
+      "D3-Q4": [
+        "PolicyContradictionDetector._detect_temporal_conflicts",
+        "TemporalLogicVerifier._check_deadline_constraints",
+        "PolicyContradictionDetector._detect_resource_conflicts",
+        "PolicyContradictionDetector._get_context_window"
+      ],
+      "D3-Q5": [
+        "IndustrialPolicyProcessor._match_patterns_in_sentences",
+        "PolicyContradictionDetector._determine_relation_type"
+      ]
+    },
+    "D4": {
+      "D4-Q2": [
+        "IndustrialPolicyProcessor._match_patterns_in_sentences",
+        "PolicyContradictionDetector._build_knowledge_graph",
+        "PolicyContradictionDetector._determine_semantic_role"
+      ],
+      "D4-Q3": [
+        "PolicyContradictionDetector._detect_numerical_inconsistencies",
+        "PolicyContradictionDetector._calculate_objective_alignment",
+        "PDETMunicipalPlanAnalyzer.generate_recommendations"
+      ],
+      "D4-Q5": [
+        "IndustrialPolicyProcessor._match_patterns_in_sentences",
+        "PolicyContradictionDetector._calculate_global_semantic_coherence"
+      ]
+    },
+    "D5": {
+      "D5-Q1": [
+        "PolicyContradictionDetector._extract_temporal_markers",
+        "TemporalLogicVerifier._extract_resources",
+        "PolicyContradictionDetector._calculate_objective_alignment"
+      ],
+      "D5-Q2_Q3": [
+        "IndustrialPolicyProcessor._match_patterns_in_sentences",
+        "PolicyContradictionDetector._classify_contradiction",
+        "PolicyContradictionDetector._get_graph_statistics"
+      ],
+      "D5-Q4": [
+        "IndustrialPolicyProcessor._match_patterns_in_sentences",
+        "PolicyContradictionDetector._detect_logical_incompatibilities",
+        "PolicyContradictionDetector._calculate_contradiction_entropy"
+      ],
+      "D5-Q5": [
+        "IndustrialPolicyProcessor._match_patterns_in_sentences"
+      ]
+    },
+    "D6": {
+      "D6-Q1_Q2": [
+        "PolicyContradictionDetector._build_knowledge_graph",
+        "nx.DiGraph",
+        "AdvancedDAGValidator.validacion_completa",
+        "AdvancedDAGValidator._validar_orden_causal",
+        "AdvancedDAGValidator._encontrar_caminos_completos",
+        "IndustrialPolicyProcessor._match_patterns_in_sentences",
+        "PolicyContradictionDetector._calculate_syntactic_complexity"
+      ],
+      "D6-Q3_Q4": [
+        "PolicyContradictionDetector._detect_logical_incompatibilities",
+        "IndustrialPolicyProcessor._match_patterns_in_sentences",
+        "PolicyContradictionDetector._generate_resolution_recommendations"
+      ],
+      "D6-Q5": [
+        "PolicyContradictionDetector._generate_embeddings",
+        "SemanticAnalyzer._classify_cross_cutting_themes",
+        "PolicyContradictionDetector._identify_dependencies"
+      ]
+    }
+  },
+  "global_methods": [
+    "PolicyAnalysisPipeline.__init__",
+    "IndustrialPolicyProcessor.__init__",
+    "DocumentProcessor.load_pdf",
+    "DocumentProcessor.load_docx",
+    "MunicipalOntology.init",
+    "SemanticAnalyzer.init",
+    "IndustrialPolicyProcessor._compile_pattern_registry",
+    "IndustrialPolicyProcessor._build_point_patterns",
+    "PolicyContradictionDetector.init",
+    "PolicyContradictionDetector._initialize_pdm_patterns"
+  ]
+}

--- a/validation/architecture_validator.py
+++ b/validation/architecture_validator.py
@@ -1,0 +1,333 @@
+"""Architecture validation utilities for the municipal policy analysis system.
+
+This module provides helpers to enforce that the municipal policy
+analysis architecture blueprint references real, implemented methods.
+It parses the ``policy_analysis_architecture.json`` specification,
+compares every referenced method against the inventoried codebase and
+produces coverage reports per analytical dimension.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional, Set, Tuple
+
+# Regular expression used to capture fully-qualified method references such as
+# ``ClassName.method_name``.
+METHOD_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*$")
+
+_EXTERNAL_REFERENCE = object()
+
+ALIAS_MAP: Dict[str, object] = {
+    # Performance analyzer exposes the functionality through a private helper.
+    "PerformanceAnalyzer.analyze_loss_function": "PerformanceAnalyzer._calculate_loss_functions",
+    # The municipal plan analyzer generates recommendations with a private helper.
+    "PDETMunicipalPlanAnalyzer.generate_recommendations": "PDETMunicipalPlanAnalyzer._generate_recommendations",
+    # Advanced DAG validation leverages TeoriaCambio utilities internally.
+    "AdvancedDAGValidator.validacion_completa": "TeoriaCambio.validacion_completa",
+    "AdvancedDAGValidator._validar_orden_causal": "TeoriaCambio._validar_orden_causal",
+    "AdvancedDAGValidator._encontrar_caminos_completos": "TeoriaCambio._encontrar_caminos_completos",
+    # External dependency references (networkx graphs).
+    "nx.DiGraph": _EXTERNAL_REFERENCE,
+}
+
+# Root directory of the repository (two levels above this file).
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+
+@dataclass(frozen=True)
+class ArchitectureValidationResult:
+    """Container with the outcome of the architecture validation process."""
+
+    resolved_methods: Set[str]
+    missing_methods: Mapping[str, Mapping[str, List[str]]]
+    coverage: float
+    total_spec_methods: int
+    total_available_methods: int
+    per_dimension: Mapping[str, Mapping[str, List[str]]]
+    global_methods: Tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise the validation result into a JSON-compatible dict."""
+
+        return {
+            "coverage": self.coverage,
+            "total_spec_methods": self.total_spec_methods,
+            "total_available_methods": self.total_available_methods,
+            "resolved_methods": sorted(self.resolved_methods),
+            "missing_methods": {
+                dimension: {question: methods for question, methods in question_map.items()}
+                for dimension, question_map in self.missing_methods.items()
+            },
+            "per_dimension": {
+                dimension: {question: methods for question, methods in question_map.items()}
+                for dimension, question_map in self.per_dimension.items()
+            },
+            "global_methods": list(self.global_methods),
+        }
+
+
+def load_architecture_spec(path: Path) -> Dict[str, object]:
+    """Load the JSON architecture specification from ``path``."""
+
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _extract_method_from_entry(entry: object) -> Optional[str]:
+    """Return the method string encoded in ``entry`` if present."""
+
+    if isinstance(entry, str) and METHOD_PATTERN.match(entry):
+        return entry
+
+    if isinstance(entry, Mapping):
+        # Architecture steps are stored as {"Class.method": "description"}
+        for key in entry.keys():
+            if isinstance(key, str) and METHOD_PATTERN.match(key):
+                return key
+
+        # Some entries are dictionaries using {"name": "method"}. These lack
+        # class information and therefore cannot be enforced reliably.
+        name = entry.get("name") if isinstance(entry.get("name"), str) else None
+        if name and METHOD_PATTERN.match(name):
+            return name
+
+    return None
+
+
+def _extract_methods_from_string(value: str) -> Iterable[str]:
+    """Extract additional method references embedded in textual descriptions."""
+
+    for candidate in re.findall(r"[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*", value):
+        if METHOD_PATTERN.match(candidate):
+            yield candidate
+
+
+def extract_architecture_methods(spec: Mapping[str, object]) -> Tuple[Dict[str, Dict[str, List[str]]], List[str]]:
+    """Extract method sequences per dimension and global method references."""
+
+    policy_spec = spec.get("policy_analysis_architecture", {})
+    if not isinstance(policy_spec, Mapping):
+        raise ValueError("Malformed architecture specification: missing 'policy_analysis_architecture'.")
+
+    per_dimension: Dict[str, Dict[str, List[str]]] = {}
+    global_methods: List[str] = []
+
+    # --- Component level methods -------------------------------------------------
+    orchestration = policy_spec.get("orchestration_flow", {})
+    if isinstance(orchestration, Mapping):
+        for component in orchestration.get("components", []):
+            if not isinstance(component, Mapping):
+                continue
+            for entry in component.get("key_methods", []):
+                method = _extract_method_from_entry(entry)
+                if method:
+                    global_methods.append(method.strip())
+                if isinstance(entry, Mapping):
+                    description = entry.get("description")
+                    if isinstance(description, str):
+                        global_methods.extend(list(_extract_methods_from_string(description)))
+
+    # --- Phase 0 (initialisation) -------------------------------------------------
+    phase_zero = policy_spec.get("phase_0_inicializacion_y_carga", {})
+    if isinstance(phase_zero, Mapping):
+        for step in phase_zero.get("steps", []):
+            if not isinstance(step, Mapping):
+                continue
+            for action in step.get("actions", []):
+                method = _extract_method_from_entry(action)
+                if method:
+                    global_methods.append(method.strip())
+                if isinstance(action, Mapping):
+                    for value in action.values():
+                        if isinstance(value, str):
+                            global_methods.extend(list(_extract_methods_from_string(value)))
+
+    # --- Analytical dimensions ----------------------------------------------------
+    for dimension in policy_spec.get("dimensiones", []):
+        if not isinstance(dimension, Mapping):
+            continue
+        dim_id = str(dimension.get("id", "UNKNOWN"))
+        dimension_methods: Dict[str, List[str]] = {}
+        for subdimension in dimension.get("subdimension", []):
+            if not isinstance(subdimension, Mapping):
+                continue
+            question_id = str(subdimension.get("pregunta", "UNKNOWN"))
+            methods: List[str] = []
+            for step in subdimension.get("cadena_metodos", []):
+                method = _extract_method_from_entry(step)
+                if method:
+                    methods.append(method.strip())
+                if isinstance(step, Mapping):
+                    for value in step.values():
+                        if isinstance(value, str):
+                            methods.extend(list(_extract_methods_from_string(value)))
+            dimension_methods[question_id] = methods
+        if dimension_methods:
+            per_dimension[dim_id] = dimension_methods
+
+    # --- Transversal modules ------------------------------------------------------
+    transversal = policy_spec.get("modulos_transversales", {})
+    if isinstance(transversal, Mapping):
+        metricas = transversal.get("metricas_rendimiento", {})
+        if isinstance(metricas, Mapping):
+            for component in metricas.get("componentes", []):
+                if not isinstance(component, Mapping):
+                    continue
+                method = _extract_method_from_entry(component)
+                if method:
+                    global_methods.append(method.strip())
+                description = component.get("descripcion") or component.get("description")
+                if isinstance(description, str):
+                    global_methods.extend(list(_extract_methods_from_string(description)))
+
+    return per_dimension, global_methods
+
+
+def load_method_inventory(path: Path) -> Tuple[Set[str], Set[str]]:
+    """Load available class methods and module functions from the inventory."""
+
+    with path.open("r", encoding="utf-8") as handle:
+        inventory = json.load(handle)
+
+    available_methods: Set[str] = set()
+    functions: Set[str] = set()
+
+    candidate_files = inventory.get("files", {})
+    for file_name in candidate_files.keys():
+        file_path = ROOT_DIR / file_name
+        if not file_path.exists():
+            continue
+        try:
+            tree = ast.parse(file_path.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef):
+                functions.add(node.name)
+            elif isinstance(node, ast.AsyncFunctionDef):
+                functions.add(node.name)
+            elif isinstance(node, ast.ClassDef):
+                for item in node.body:
+                    if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        available_methods.add(f"{node.name}.{item.name}")
+
+    return available_methods, functions
+
+
+def _resolve_method_reference(
+    reference: str,
+    available_methods: Set[str],
+    available_functions: Set[str],
+) -> Optional[str]:
+    """Resolve a method reference using the available inventory."""
+
+    reference = reference.strip()
+
+    alias_target = ALIAS_MAP.get(reference)
+    if alias_target is _EXTERNAL_REFERENCE:
+        return reference
+    if isinstance(alias_target, str):
+        if alias_target == reference:
+            return reference if reference in available_methods else None
+        resolved_alias = _resolve_method_reference(alias_target, available_methods, available_functions)
+        if resolved_alias:
+            return resolved_alias
+
+    if METHOD_PATTERN.match(reference):
+        if reference in available_methods:
+            return reference
+        # Allow ``Class.init`` aliases for ``Class.__init__``
+        if reference.endswith(".init"):
+            init_alias = reference[:-4] + "__init__"
+            if init_alias in available_methods:
+                return init_alias
+        return None
+
+    # Plain function reference
+    if reference in available_functions:
+        return reference
+    return None
+
+
+def validate_architecture(spec_path: Path, inventory_path: Path) -> ArchitectureValidationResult:
+    """Validate that every method described in the architecture exists."""
+
+    spec = load_architecture_spec(spec_path)
+    per_dimension, global_methods = extract_architecture_methods(spec)
+
+    available_methods, available_functions = load_method_inventory(inventory_path)
+
+    resolved_methods: Set[str] = set()
+    missing_methods: Dict[str, Dict[str, List[str]]] = {}
+
+    # Validate global references
+    for method in global_methods:
+        resolved = _resolve_method_reference(method, available_methods, available_functions)
+        if resolved:
+            resolved_methods.add(resolved)
+        else:
+            missing_methods.setdefault("__global__", {}).setdefault("__global__", []).append(method)
+
+    # Validate per-dimension references
+    for dimension, question_map in per_dimension.items():
+        for question, methods in question_map.items():
+            for method in methods:
+                resolved = _resolve_method_reference(method, available_methods, available_functions)
+                if resolved:
+                    resolved_methods.add(resolved)
+                else:
+                    missing_methods.setdefault(dimension, {}).setdefault(question, []).append(method)
+
+    total_references = len(global_methods)
+    total_references += sum(len(methods) for question_map in per_dimension.values() for methods in question_map.values())
+    total_references = max(total_references, 1)
+
+    coverage = len(resolved_methods) / total_references
+
+    return ArchitectureValidationResult(
+        resolved_methods=resolved_methods,
+        missing_methods=missing_methods,
+        coverage=coverage,
+        total_spec_methods=total_references,
+        total_available_methods=len(available_methods),
+        per_dimension=per_dimension,
+        global_methods=tuple(global_methods),
+    )
+
+
+def write_validation_report(result: ArchitectureValidationResult, output_path: Path) -> None:
+    """Write the validation report to ``output_path`` in JSON format."""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
+        json.dump(result.to_dict(), handle, indent=2, ensure_ascii=False)
+
+
+def main() -> None:
+    """Entry point for CLI usage."""
+
+    spec_path = ROOT_DIR / "policy_analysis_architecture.json"
+    inventory_path = ROOT_DIR / "COMPLETE_METHOD_CLASS_MAP.json"
+    report_path = ROOT_DIR / "validation" / "architecture_validation_report.json"
+
+    result = validate_architecture(spec_path, inventory_path)
+    write_validation_report(result, report_path)
+
+    if result.missing_methods:
+        missing_total = sum(len(methods) for dimension in result.missing_methods.values() for methods in dimension.values())
+        print(
+            f"Architecture validation completed with {missing_total} missing methods. "
+            f"Report saved to {report_path}."
+        )
+    else:
+        print(f"Architecture validation successful. Report saved to {report_path}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- anchor the canonical question segmenter output to `(Q, PA, DIM)` tuples and expose an index for downstream validation
- add a JSON schema that codifies the canonical segmentation payload for contract attestation
- extend the contract tests to assert ordering, schema compliance (when available), and negative-control coverage ratios

## Testing
- pytest tests/test_document_processor_segmenter.py

------
https://chatgpt.com/codex/tasks/task_e_68fa948a911c83288ec16585ce253f34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Canonical question segmentation system with deterministic evidence manifesting and contract hashing
  * Architecture validation framework with method resolution coverage reporting

* **Tests**
  * Added architecture validator and document processor segmenter test suites

* **Documentation**
  * New JSON schema defining canonical question segmentation output structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->