### PR TITLE
Align orchestrator control plane with YAML documentation

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -365,7 +365,8 @@ class PolicyAnalysisOrchestrator:
         """
         Load rubric_scoring configuration for weighting and aggregation.
 
-        Includes YAML causal_thresholds and dimension-specific scoring rules.
+        Includes causal_thresholds and dimension-specific scoring rules.
+        Note: Currently expects JSON input; if using YAML, add a YAML loader.
         """
         rubric_path = self.config.rubric_path
         logger.info(f"Loading rubric configuration: {rubric_path}")


### PR DESCRIPTION
## Summary
- update the orchestrator header and class documentation to match the YAML-aligned control plane script and emphasize delegation to the choreographer
- adjust initialization, logging, performance metrics, and provenance to reflect deterministic seeds and YAML component coverage
- refresh execution helper docstrings to describe CHESS phases, data flow, and the MESO/MACRO aggregation process

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff57611cc48328b776c27338d9096a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Clarified MACRO/MICRO architecture and delegation to the execution choreographer; improved per-phase execution messaging (OPENING/MIDDLE/ENDGAME) that lists YAML components used.

* **New Features**
  * Result payloads now include expanded provenance and metadata (execution_id, ISO timestamp, yaml_version/date, questionnaire_hash, run_seed, plan metadata).
  * Added performance metrics: average_time_per_question, questions_per_second, total_execution_time; avg_question_time retained for compatibility.

* **Documentation**
  * Enhanced runtime banners, logging, and docstrings to emphasize YAML v1.0 alignment and component usage.

*Note: No user-facing behavior changes beyond richer logs and result metadata.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->