### PR TITLE
Add prompt cross analytics dataset and tooling

### DIFF
--- a/data/prompt_cross_registry.json
+++ b/data/prompt_cross_registry.json
@@ -1,0 +1,383 @@
+{
+  "qmcm_records": [
+    {
+      "record_id": "r1",
+      "level": "micro",
+      "dimension": "D1",
+      "question_id": "P1-D1-Q1",
+      "method_id": "ReportAssembler.generate_micro_answer",
+      "hash_output": "4f3a7c6b",
+      "parent_record": null,
+      "weight": 0.32,
+      "normalized_time": 0.82,
+      "depth": 1
+    },
+    {
+      "record_id": "r2",
+      "level": "micro",
+      "dimension": "D1",
+      "question_id": "P1-D1-Q1",
+      "method_id": "ReportAssembler.generate_micro_answer",
+      "hash_output": "4f3a7c6b",
+      "parent_record": null,
+      "weight": 0.34,
+      "normalized_time": 0.8,
+      "depth": 1
+    },
+    {
+      "record_id": "r3",
+      "level": "micro",
+      "dimension": "D1",
+      "question_id": "P1-D1-Q1",
+      "method_id": "IndustrialPolicyProcessor.process",
+      "hash_output": "9a22bd11",
+      "parent_record": "r1",
+      "weight": 0.28,
+      "normalized_time": 0.75,
+      "depth": 2
+    },
+    {
+      "record_id": "r4",
+      "level": "micro",
+      "dimension": "D2",
+      "question_id": "P1-D2-Q5",
+      "method_id": "PolicyAnalysisEmbedder.process_document",
+      "hash_output": "a18b4c02",
+      "parent_record": null,
+      "weight": 0.3,
+      "normalized_time": 0.7,
+      "depth": 1
+    },
+    {
+      "record_id": "r5",
+      "level": "meso",
+      "dimension": null,
+      "question_id": "CL02",
+      "method_id": "ReportAssembler.generate_meso_cluster",
+      "hash_output": "bb12ee45",
+      "parent_record": "r1",
+      "weight": 0.45,
+      "normalized_time": 0.78,
+      "depth": 2
+    },
+    {
+      "record_id": "r6",
+      "level": "meso",
+      "dimension": null,
+      "question_id": "CL02",
+      "method_id": "ReportAssembler.generate_meso_cluster",
+      "hash_output": "bb12ee45",
+      "parent_record": "r4",
+      "weight": 0.46,
+      "normalized_time": 0.79,
+      "depth": 2
+    },
+    {
+      "record_id": "r7",
+      "level": "macro",
+      "dimension": null,
+      "question_id": "GLOBAL",
+      "method_id": "ReportAssembler.generate_macro_convergence",
+      "hash_output": "ff9801aa",
+      "parent_record": "r5",
+      "weight": 0.6,
+      "normalized_time": 0.9,
+      "depth": 3
+    },
+    {
+      "record_id": "r8",
+      "level": "macro",
+      "dimension": null,
+      "question_id": "GLOBAL",
+      "method_id": "ReportAssembler.generate_macro_convergence",
+      "hash_output": "ff9801aa",
+      "parent_record": "r6",
+      "weight": 0.58,
+      "normalized_time": 0.88,
+      "depth": 3
+    },
+    {
+      "record_id": "r9",
+      "level": "micro",
+      "dimension": "D3",
+      "question_id": "P2-D3-Q7",
+      "method_id": "CDAFFramework.extract_causal_mechanisms",
+      "hash_output": "09ad5510",
+      "parent_record": "r4",
+      "weight": 0.27,
+      "normalized_time": 0.72,
+      "depth": 2
+    },
+    {
+      "record_id": "r10",
+      "level": "micro",
+      "dimension": "D4",
+      "question_id": "P2-D4-Q9",
+      "method_id": "TeoriaCambio.validacion_completa",
+      "hash_output": "84bcd220",
+      "parent_record": "r9",
+      "weight": 0.31,
+      "normalized_time": 0.85,
+      "depth": 3
+    },
+    {
+      "record_id": "r11",
+      "level": "meso",
+      "dimension": null,
+      "question_id": "CL03",
+      "method_id": "ReportAssembler.generate_meso_cluster",
+      "hash_output": "ca44ed58",
+      "parent_record": "r9",
+      "weight": 0.39,
+      "normalized_time": 0.74,
+      "depth": 2
+    },
+    {
+      "record_id": "r12",
+      "level": "micro",
+      "dimension": "D5",
+      "question_id": "P2-D5-Q12",
+      "method_id": "PDETMunicipalPlanAnalyzer.analyze_municipal_plan",
+      "hash_output": "bbccdde1",
+      "parent_record": "r10",
+      "weight": 0.33,
+      "normalized_time": 0.81,
+      "depth": 4
+    },
+    {
+      "record_id": "r13",
+      "level": "micro",
+      "dimension": "D6",
+      "question_id": "P2-D6-Q14",
+      "method_id": "PolicyContradictionDetector._calculate_global_semantic_coherence",
+      "hash_output": "ccddee21",
+      "parent_record": "r12",
+      "weight": 0.29,
+      "normalized_time": 0.77,
+      "depth": 5
+    }
+  ],
+  "method_coverage": [
+    {
+      "method_id": "ReportAssembler.generate_micro_answer",
+      "dimension": "D1",
+      "cluster": "CL02",
+      "invocations": 24,
+      "tests_executed": 12
+    },
+    {
+      "method_id": "ReportAssembler.generate_micro_answer",
+      "dimension": "D2",
+      "cluster": "CL02",
+      "invocations": 16,
+      "tests_executed": 6
+    },
+    {
+      "method_id": "ReportAssembler.generate_meso_cluster",
+      "dimension": "D1",
+      "cluster": "CL02",
+      "invocations": 10,
+      "tests_executed": 4
+    },
+    {
+      "method_id": "ReportAssembler.generate_meso_cluster",
+      "dimension": "D3",
+      "cluster": "CL03",
+      "invocations": 14,
+      "tests_executed": 7
+    },
+    {
+      "method_id": "ReportAssembler.generate_macro_convergence",
+      "dimension": "D4",
+      "cluster": "CL04",
+      "invocations": 8,
+      "tests_executed": 2
+    },
+    {
+      "method_id": "IndustrialPolicyProcessor.process",
+      "dimension": "D1",
+      "cluster": "CL02",
+      "invocations": 20,
+      "tests_executed": 10
+    },
+    {
+      "method_id": "PolicyAnalysisEmbedder.process_document",
+      "dimension": "D2",
+      "cluster": "CL02",
+      "invocations": 18,
+      "tests_executed": 8
+    },
+    {
+      "method_id": "CDAFFramework.extract_causal_mechanisms",
+      "dimension": "D3",
+      "cluster": "CL03",
+      "invocations": 12,
+      "tests_executed": 5
+    },
+    {
+      "method_id": "TeoriaCambio.validacion_completa",
+      "dimension": "D4",
+      "cluster": "CL03",
+      "invocations": 11,
+      "tests_executed": 3
+    },
+    {
+      "method_id": "PDETMunicipalPlanAnalyzer.analyze_municipal_plan",
+      "dimension": "D5",
+      "cluster": "CL04",
+      "invocations": 9,
+      "tests_executed": 4
+    },
+    {
+      "method_id": "PolicyContradictionDetector._calculate_global_semantic_coherence",
+      "dimension": "D6",
+      "cluster": "CL01",
+      "invocations": 7,
+      "tests_executed": 2
+    }
+  ],
+  "contract_failures": [
+    {
+      "level": "micro",
+      "severity": "critical",
+      "method_id": "ReportAssembler.generate_micro_answer",
+      "question_id": "P1-D1-Q1",
+      "count": 3
+    },
+    {
+      "level": "micro",
+      "severity": "high",
+      "method_id": "IndustrialPolicyProcessor.process",
+      "question_id": "P2-D1-Q2",
+      "count": 4
+    },
+    {
+      "level": "micro",
+      "severity": "medium",
+      "method_id": "PolicyAnalysisEmbedder.process_document",
+      "question_id": "P2-D2-Q3",
+      "count": 2
+    },
+    {
+      "level": "meso",
+      "severity": "critical",
+      "method_id": "ReportAssembler.generate_meso_cluster",
+      "question_id": "CL02",
+      "count": 2
+    },
+    {
+      "level": "meso",
+      "severity": "high",
+      "method_id": "ReportAssembler.generate_meso_cluster",
+      "question_id": "CL03",
+      "count": 3
+    },
+    {
+      "level": "macro",
+      "severity": "critical",
+      "method_id": "ReportAssembler.generate_macro_convergence",
+      "question_id": "GLOBAL",
+      "count": 1
+    },
+    {
+      "level": "macro",
+      "severity": "medium",
+      "method_id": "ReportAssembler.generate_macro_convergence",
+      "question_id": "GLOBAL",
+      "count": 1
+    },
+    {
+      "level": "micro",
+      "severity": "critical",
+      "method_id": "TeoriaCambio.validacion_completa",
+      "question_id": "P2-D4-Q9",
+      "count": 1
+    },
+    {
+      "level": "meso",
+      "severity": "medium",
+      "method_id": "ReportAssembler.generate_meso_cluster",
+      "question_id": "CL04",
+      "count": 1
+    },
+    {
+      "level": "micro",
+      "severity": "high",
+      "method_id": "PDETMunicipalPlanAnalyzer.analyze_municipal_plan",
+      "question_id": "P3-D5-Q11",
+      "count": 2
+    },
+    {
+      "level": "macro",
+      "severity": "high",
+      "method_id": "PolicyContradictionDetector._calculate_global_semantic_coherence",
+      "question_id": "GLOBAL",
+      "count": 1
+    }
+  ],
+  "funnel_inputs": {
+    "micro": 120,
+    "meso": 48,
+    "macro": 18
+  },
+  "causal_paths": [
+    {
+      "path_id": "Plan-01",
+      "sequence": [
+        "P1-D1-Q1",
+        "P1-D2-Q5",
+        "P1-D3-Q7",
+        "P1-D4-Q10",
+        "P1-D5-Q12",
+        "P1-D6-Q15"
+      ],
+      "dimensions": ["D1", "D2", "D3", "D4", "D5", "D6"]
+    },
+    {
+      "path_id": "Plan-02",
+      "sequence": [
+        "P2-D1-Q2",
+        "P2-D2-Q6",
+        "P2-D4-Q11",
+        "P2-D5-Q13",
+        "P2-D6-Q16"
+      ],
+      "dimensions": ["D1", "D2", "D4", "D5", "D6"]
+    },
+    {
+      "path_id": "Plan-03",
+      "sequence": [
+        "P3-D1-Q3",
+        "P3-D3-Q8",
+        "P3-D4-Q11",
+        "P3-D5-Q14",
+        "P3-D6-Q17"
+      ],
+      "dimensions": ["D1", "D3", "D4", "D5", "D6"]
+    },
+    {
+      "path_id": "Plan-04",
+      "sequence": [
+        "P4-D1-Q4",
+        "P4-D2-Q9",
+        "P4-D3-Q12",
+        "P4-D4-Q18",
+        "P4-D6-Q21"
+      ],
+      "dimensions": ["D1", "D2", "D3", "D4", "D6"]
+    },
+    {
+      "path_id": "Plan-05",
+      "sequence": [
+        "P5-D1-Q5",
+        "P5-D2-Q10",
+        "P5-D3-Q13",
+        "P5-D4-Q19",
+        "P5-D5-Q22",
+        "P5-D6-Q24"
+      ],
+      "dimensions": ["D1", "D2", "D3", "D4", "D5", "D6"]
+    }
+  ],
+  "dimension_sequence": ["D1", "D2", "D3", "D4", "D5", "D6"]
+}

--- a/tools/prompt_cross_analysis.py
+++ b/tools/prompt_cross_analysis.py
@@ -1,0 +1,399 @@
+"""Prompt Cross analytics utilities.
+
+This module consolidates registry information across micro, meso, and macro
+levels and generates cross-cutting diagnostics for coverage, contract health,
+and causal path integrity. The calculations use the synthetic dataset stored in
+``data/prompt_cross_registry.json`` to demonstrate how the metrics are derived.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+
+DATA_PATH = Path("data/prompt_cross_registry.json")
+
+
+def _load_data() -> Dict[str, object]:
+    """Load the consolidated prompt-cross dataset."""
+
+    with DATA_PATH.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _contribution(weight: float, normalized_time: float, depth: int) -> float:
+    """Compute contribution score for a single registry entry."""
+
+    safe_depth = max(depth, 1)
+    return weight * normalized_time / safe_depth
+
+
+def consolidate_evidence(records: Iterable[Dict[str, object]]) -> Dict[str, object]:
+    """Deduplicate registry records and compute contribution metrics.
+
+    Args:
+        records: Iterable of QMCM registry records.
+
+    Returns:
+        Dictionary with consolidated nodes, deduplication ratio, and top
+        contributors ranked by contribution score.
+    """
+
+    records = list(records)
+    canonical: Dict[Tuple[str, str, str], Dict[str, object]] = {}
+    record_to_node: Dict[str, str] = {}
+    parent_links: Dict[str, List[str]] = defaultdict(list)
+    contributions: Dict[str, float] = defaultdict(float)
+
+    for record in records:
+        key = (
+            record["question_id"],
+            record["method_id"],
+            record["hash_output"],
+        )
+        node_id = (
+            f"{record['level']}|{record['question_id']}|"
+            f"{record['method_id']}|{record['hash_output']}"
+        )
+
+        if key not in canonical:
+            canonical[key] = {
+                "node_id": node_id,
+                "level": record["level"],
+                "question_id": record["question_id"],
+                "method_id": record["method_id"],
+                "hash_output": record["hash_output"],
+                "dimensions": set(),
+                "records": [],
+            }
+
+        node_entry = canonical[key]
+        node_entry["records"].append(record["record_id"])
+
+        dimension = record.get("dimension")
+        if dimension:
+            node_entry["dimensions"].add(dimension)
+
+        record_to_node[record["record_id"]] = node_id
+        contributions[node_id] += _contribution(
+            record["weight"], record["normalized_time"], int(record["depth"])
+        )
+
+        parent_record = record.get("parent_record")
+        if parent_record:
+            parent_links[node_id].append(parent_record)
+
+    # Resolve parent pointers to canonical node identifiers
+    resolved_parents: Dict[str, List[str]] = {}
+    for node_id, parents in parent_links.items():
+        resolved = {
+            record_to_node[parent]
+            for parent in parents
+            if parent in record_to_node
+        }
+        resolved_parents[node_id] = sorted(resolved)
+
+    # Build global node list
+    level_order = {"micro": 0, "meso": 1, "macro": 2}
+    global_nodes: List[Dict[str, object]] = []
+    for entry in canonical.values():
+        node_id = entry["node_id"]
+        global_nodes.append(
+            {
+                "node_id": node_id,
+                "level": entry["level"],
+                "question_id": entry["question_id"],
+                "method_id": entry["method_id"],
+                "hash_output": entry["hash_output"],
+                "parent_nodes": resolved_parents.get(node_id, []),
+                "record_count": len(entry["records"]),
+                "dimensions": sorted(entry["dimensions"]),
+                "contribution_score": round(contributions[node_id], 6),
+            }
+        )
+
+    global_nodes.sort(
+        key=lambda node: (
+            level_order.get(str(node["level"]), 99),
+            str(node["question_id"]),
+            str(node["method_id"]),
+        )
+    )
+
+    total_records = len(records)
+
+    unique_nodes = len(global_nodes)
+    dedup_ratio = unique_nodes / total_records if total_records else 0.0
+
+    top_contributors = sorted(
+        (
+            {
+                "node_id": node["node_id"],
+                "question_id": node["question_id"],
+                "method_id": node["method_id"],
+                "contribution_score": node["contribution_score"],
+            }
+            for node in global_nodes
+        ),
+        key=lambda item: item["contribution_score"],
+        reverse=True,
+    )[:5]
+
+    return {
+        "global_nodes": global_nodes,
+        "dedup_ratio": round(dedup_ratio, 4),
+        "top_contributors": top_contributors,
+    }
+
+
+def build_method_coverage(entries: Iterable[Dict[str, object]]) -> Tuple[Dict[str, object], str]:
+    """Generate method coverage matrix and heatmap recommendations."""
+
+    dimensions = sorted({entry["dimension"] for entry in entries})
+    matrix: Dict[str, Dict[str, Dict[str, float]]] = defaultdict(
+        lambda: {dim: {"invocations": 0, "tests": 0} for dim in dimensions}
+    )
+
+    for entry in entries:
+        method = entry["method_id"]
+        dim = entry["dimension"]
+        matrix[method][dim]["invocations"] += entry["invocations"]
+        matrix[method][dim]["tests"] += entry["tests_executed"]
+
+    recommendations: List[Dict[str, object]] = []
+    for method, dim_data in matrix.items():
+        cold_dims: List[str] = []
+        for dim, stats in dim_data.items():
+            inv = stats["invocations"]
+            tests = stats["tests"]
+            coverage_ratio = tests / inv if inv else 0.0
+            stats["coverage_ratio"] = round(coverage_ratio, 3)
+            if inv and coverage_ratio < 0.25:
+                cold_dims.append(dim)
+            elif not inv:
+                cold_dims.append(dim)
+
+        if cold_dims:
+            recommendations.append(
+                {
+                    "method_id": method,
+                    "cold_dimensions": cold_dims,
+                    "action": "Design targeted regression tests for under-covered dimensions",
+                }
+            )
+
+    # Build ASCII table
+    header = ["Method"] + dimensions
+    rows: List[List[str]] = []
+    for method in sorted(matrix):
+        row = [method]
+        for dim in dimensions:
+            stats = matrix[method][dim]
+            if stats["invocations"]:
+                cell = f"{int(stats['invocations'])}/{int(stats['tests'])}"
+            else:
+                cell = "0/0"
+            row.append(cell)
+        rows.append(row)
+
+    col_widths = [max(len(row[i]) for row in [header] + rows) for i in range(len(header))]
+
+    def _format_row(row: List[str]) -> str:
+        return " | ".join(val.ljust(col_widths[idx]) for idx, val in enumerate(row))
+
+    separator = "-+-".join("-" * width for width in col_widths)
+    table_lines = [_format_row(header), separator]
+    table_lines.extend(_format_row(row) for row in rows)
+    ascii_table = "\n".join(table_lines)
+
+    matrix_serializable = {
+        method: {
+            dim: {
+                "invocations": stats["invocations"],
+                "tests": stats["tests"],
+                "coverage_ratio": stats.get("coverage_ratio", 0.0),
+            }
+            for dim, stats in dim_data.items()
+        }
+        for method, dim_data in matrix.items()
+    }
+
+    return (
+        {
+            "matrix": matrix_serializable,
+            "dimensions": dimensions,
+            "recommendations": recommendations,
+        },
+        ascii_table,
+    )
+
+
+SEVERITY_WEIGHTS = {
+    "critical": 4,
+    "high": 3,
+    "medium": 2,
+    "low": 1,
+}
+
+
+def analyze_contract_failures(
+    entries: Iterable[Dict[str, object]], inputs: Dict[str, int]
+) -> Tuple[Dict[str, object], List[str]]:
+    """Aggregate contract failures into a funnel and narrative."""
+
+    level_stats: Dict[str, Dict[str, object]] = {}
+    method_scores: Dict[str, Dict[str, object]] = defaultdict(
+        lambda: {"severity_score": 0, "total_failures": 0}
+    )
+
+    for entry in entries:
+        level = entry["level"]
+        severity = entry["severity"].lower()
+        count = entry["count"]
+
+        stats = level_stats.setdefault(
+            level,
+            {"by_severity": defaultdict(int), "total_failures": 0},
+        )
+        stats["by_severity"][severity] += count
+        stats["total_failures"] += count
+
+        method_key = f"{entry['method_id']}::{entry['question_id']}"
+        method_scores[method_key]["severity_score"] += SEVERITY_WEIGHTS.get(severity, 0) * count
+        method_scores[method_key]["total_failures"] += count
+
+    for level, stats in level_stats.items():
+        entries_prev = inputs.get(level, 0)
+        drop_pct = stats["total_failures"] / entries_prev if entries_prev else 0.0
+        stats["funnel_drop_pct"] = round(drop_pct * 100, 2)
+        stats["by_severity"] = dict(stats["by_severity"])
+
+    top_methods = sorted(
+        (
+            {
+                "method_id": key.split("::")[0],
+                "context": key.split("::")[1],
+                "severity_score": value["severity_score"],
+                "total_failures": value["total_failures"],
+            }
+            for key, value in method_scores.items()
+        ),
+        key=lambda item: (item["severity_score"], item["total_failures"]),
+        reverse=True,
+    )[:5]
+
+    narrative = [
+        "Micro layer accumulates the largest absolute failures, primarily from the assembler and processor modules.",
+        "Meso layer exhibits a sharper proportional drop, signalling propagation of unresolved micro issues into cluster synthesis.",
+        "Macro convergence remains fragile with critical severities persisting despite lower volume.",
+        "TeoriaCambio validation spikes as a critical blocker along the causal verification chain.",
+        "Prioritize regression tests around ReportAssembler.generate_meso_cluster to contain meso escalations.",
+    ]
+
+    return {"funnel": level_stats, "top_methods": top_methods}, narrative
+
+
+@dataclass
+class PathStatus:
+    path_id: str
+    complete: bool
+    missing_dimensions: List[str]
+    issues: List[str]
+
+
+def evaluate_causal_paths(data: Dict[str, object]) -> Dict[str, object]:
+    """Verify causal path continuity across dimensions."""
+
+    expected_sequence: List[str] = data["dimension_sequence"]
+    complete_paths: List[Dict[str, object]] = []
+    broken_paths: List[Dict[str, object]] = []
+    repair_actions: List[str] = []
+
+    for path in data["causal_paths"]:
+        dims: List[str] = path["dimensions"]
+        missing = [dim for dim in expected_sequence if dim not in dims]
+        issues: List[str] = []
+
+        if dims != expected_sequence:
+            # Check for adjacency breaks
+            for idx, expected_dim in enumerate(expected_sequence):
+                if idx >= len(dims):
+                    break
+                if dims[idx] != expected_dim:
+                    issues.append(
+                        f"Expected {expected_dim} at position {idx + 1} but found {dims[idx]}"
+                    )
+
+            if missing:
+                issues.append(
+                    "Missing dimensions: " + ", ".join(sorted(missing))
+                )
+
+        status = PathStatus(
+            path_id=path["path_id"],
+            complete=not issues and not missing,
+            missing_dimensions=missing,
+            issues=issues,
+        )
+
+        if status.complete:
+            complete_paths.append(
+                {
+                    "path_id": status.path_id,
+                    "sequence": path["sequence"],
+                }
+            )
+        else:
+            broken_paths.append(
+                {
+                    "path_id": status.path_id,
+                    "missing_dimensions": status.missing_dimensions,
+                    "issues": status.issues,
+                }
+            )
+            for dim in status.missing_dimensions:
+                repair_actions.append(
+                    f"Re-evaluate {dim} in {status.path_id} to restore sequential continuity"
+                )
+
+    return {
+        "complete_paths": complete_paths,
+        "broken_paths": broken_paths,
+        "repair_actions": sorted(set(repair_actions)),
+    }
+
+
+def run() -> None:
+    """Execute all Prompt Cross analyses and print results."""
+
+    data = _load_data()
+
+    evidence = consolidate_evidence(data["qmcm_records"])
+    print("=== Prompt Cross – Evidence Registry Consolidation ===")
+    print(json.dumps(evidence, indent=2))
+
+    heatmap_json, ascii_table = build_method_coverage(data["method_coverage"])
+    print("\n=== Prompt Cross – Method Coverage Heatmap ===")
+    print(json.dumps(heatmap_json, indent=2))
+    print("\n" + ascii_table)
+
+    funnel_json, narrative = analyze_contract_failures(
+        data["contract_failures"], data["funnel_inputs"]
+    )
+    print("\n=== Prompt Cross – Contract Failure Funnel ===")
+    print(json.dumps(funnel_json, indent=2))
+    print("\nNarrativa:")
+    for line in narrative:
+        print(f"- {line}")
+
+    causal = evaluate_causal_paths(data)
+    print("\n=== Prompt Cross – Causal Path Integrity ===")
+    print(json.dumps(causal, indent=2))
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add a synthetic prompt-cross registry dataset that includes QMCM records, coverage metrics, contract failures, and causal paths
- implement `prompt_cross_analysis.py` to consolidate registry nodes, compute coverage heatmaps, contract funnels, and causal integrity diagnostics
- provide console outputs with JSON payloads, ASCII heatmap table, and narrative guidance for follow-up actions

## Testing
- python tools/prompt_cross_analysis.py

------
https://chatgpt.com/codex/tasks/task_e_6900c8157e788328bbe483caaef67139