### PR TITLE
Ensure EvidenceRegistry metadata uses timezone-aware timestamp

### DIFF
--- a/orchestrator/evidence_registry.py
+++ b/orchestrator/evidence_registry.py
@@ -37,7 +37,7 @@ import time
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
-from datetime import datetime
+from datetime import datetime, timezone
 from collections import defaultdict
 
 logger = logging.getLogger(__name__)
@@ -522,6 +522,13 @@ class EvidenceRegistry:
         # Determine previous_hash from last entry in the chain
         previous_hash = self.last_entry.entry_hash if self.last_entry else None
         
+        # Normalize metadata and ensure recorded_at timestamp
+        metadata_dict: Dict[str, Any] = dict(metadata) if metadata else {}
+        metadata_dict.setdefault(
+            "recorded_at",
+            datetime.now(timezone.utc).isoformat(),
+        )
+
         # Create evidence record
         evidence = EvidenceRecord(
             evidence_id="",  # Will be set by hash
@@ -532,7 +539,7 @@ class EvidenceRegistry:
             question_id=question_id,
             document_id=document_id,
             execution_time_ms=execution_time_ms,
-            metadata=metadata or {},
+            metadata=metadata_dict,
             previous_hash=previous_hash,
         )
         


### PR DESCRIPTION
## Summary
- ensure the evidence registry records metadata with a timezone-aware `recorded_at` value
- import `timezone` so timestamps are produced via `datetime.now(timezone.utc)` instead of manual UTC suffixes

## Testing
- pytest tests/test_evidence_registry.py

------
https://chatgpt.com/codex/tasks/task_e_6900e48f738483288a2c8ccdb79d9672