### PR TITLE
Handle zero-mean dispersion in peer calibration

### DIFF
--- a/meso_cluster_analysis.py
+++ b/meso_cluster_analysis.py
@@ -199,8 +199,9 @@ class MetricViolation:
     entity_misalignment: bool = False
     out_of_range: bool = False
 
-    def to_flag_dict(self) -> Dict[str, bool]:
+    def to_flag_dict(self) -> Dict[str, object]:
         return {
+            "metric_id": self.metric_id,
             "unit_mismatch": self.unit_mismatch,
             "stale_period": self.stale_period,
             "entity_misalignment": self.entity_misalignment,
@@ -376,7 +377,12 @@ def calibrate_against_peers(
     area_positions: Dict[str, str] = {}
     outliers: Dict[str, bool] = {}
     dispersion_values = _to_float_sequence(policy_area_scores.values())
-    cluster_cv = _safe_std(dispersion_values) / _safe_mean(dispersion_values) if dispersion_values else 0.0
+    if dispersion_values:
+        cluster_mean = _safe_mean(dispersion_values)
+        cluster_std = _safe_std(dispersion_values)
+        cluster_cv = cluster_std / cluster_mean if cluster_mean else 0.0
+    else:
+        cluster_cv = 0.0
 
     for area, score in policy_area_scores.items():
         peers = peer_context.get(area, {})

--- a/tests/test_meso_cluster_analysis.py
+++ b/tests/test_meso_cluster_analysis.py
@@ -98,3 +98,10 @@ def test_calibrate_against_peers_detects_outliers_and_positions():
     assert len(payload["outliers"]) == len(scores)
     assert len(narrative.splitlines()) >= 6
 
+
+def test_calibrate_against_peers_handles_zero_mean_scores():
+    scores = {"salud": 0.0, "educacion": 0.0, "vivienda": 0.0}
+    narrative = calibrate_against_peers(scores, peer_context={})[1]
+
+    assert "CV (~0.00)" in narrative
+


### PR DESCRIPTION
## Summary
- guard the peer calibration coefficient of variation against zero-mean dispersion inputs
- include the metric identifier in reconciliation violation records for downstream consumers
- add a regression test ensuring zero-valued clusters yield a finite CV in the narrative

## Testing
- pytest tests/test_meso_cluster_analysis.py

------
https://chatgpt.com/codex/tasks/task_e_6900e92ad3d08328a3fd0250e0e62cbc