### PR TITLE
Add architectural contract tests and orchestrator golden path coverage

### DIFF
--- a/tests/data/contract_snapshots.json
+++ b/tests/data/contract_snapshots.json
@@ -1,0 +1,93 @@
+{
+  "CDAFFrameworkInputContract": {
+    "config": "NotRequired[Dict[str, Any]]",
+    "document_text": "<class 'str'>",
+    "plan_metadata": "Dict[str, Any]"
+  },
+  "CDAFFrameworkOutputContract": {
+    "audit_results": "Dict[str, Any]",
+    "bayesian_inference": "Dict[str, Any]",
+    "causal_mechanisms": "List[Dict[str, Any]]",
+    "evidential_tests": "Dict[str, Any]"
+  },
+  "ContradictionDetectorInputContract": {
+    "config": "NotRequired[Dict[str, Any]]",
+    "dimension": "NotRequired[str]",
+    "plan_name": "<class 'str'>",
+    "text": "<class 'str'>"
+  },
+  "ContradictionDetectorOutputContract": {
+    "confidence_scores": "Dict[str, float]",
+    "contradictions": "List[Dict[str, Any]]",
+    "severity_scores": "Dict[str, float]",
+    "temporal_conflicts": "List[Dict[str, Any]]"
+  },
+  "EmbeddingPolicyInputContract": {
+    "dimensions": "NotRequired[List[str]]",
+    "model_config": "NotRequired[Dict[str, Any]]",
+    "text": "<class 'str'>"
+  },
+  "EmbeddingPolicyOutputContract": {
+    "bayesian_evaluation": "Dict[str, Any]",
+    "embeddings": "List[List[float]]",
+    "policy_metrics": "Dict[str, float]",
+    "similarity_scores": "Dict[str, float]"
+  },
+  "PDETAnalyzerInputContract": {
+    "config": "NotRequired[Dict[str, Any]]",
+    "document_content": "<class 'str'>",
+    "extract_tables": "NotRequired[bool]"
+  },
+  "PDETAnalyzerOutputContract": {
+    "extracted_tables": "List[Dict[str, Any]]",
+    "financial_indicators": "Dict[str, float]",
+    "quality_scores": "Dict[str, float]",
+    "viability_score": "<class 'float'>"
+  },
+  "PolicyProcessorInputContract": {
+    "config": "NotRequired[Dict[str, Any]]",
+    "data": "Any",
+    "sentences": "NotRequired[List[str]]",
+    "tables": "NotRequired[List[Dict[str, Any]]]",
+    "text": "<class 'str'>"
+  },
+  "PolicyProcessorOutputContract": {
+    "bayesian_scores": "Dict[str, float]",
+    "evidence_bundles": "List[Dict[str, Any]]",
+    "matched_patterns": "List[Dict[str, Any]]",
+    "processed_data": "Dict[str, Any]"
+  },
+  "SemanticAnalyzerInputContract": {
+    "ontology_params": "NotRequired[Dict[str, Any]]",
+    "segments": "NotRequired[List[str]]",
+    "text": "<class 'str'>"
+  },
+  "SemanticAnalyzerOutputContract": {
+    "coherence_score": "<class 'float'>",
+    "complexity_score": "<class 'float'>",
+    "domain_classification": "Dict[str, float]",
+    "semantic_cube": "Dict[str, Any]"
+  },
+  "SemanticChunkingInputContract": {
+    "config": "NotRequired[Dict[str, Any]]",
+    "preserve_structure": "NotRequired[bool]",
+    "text": "<class 'str'>"
+  },
+  "SemanticChunkingOutputContract": {
+    "causal_dimensions": "Dict[str, Dict[str, Any]]",
+    "chunks": "List[Dict[str, Any]]",
+    "key_excerpts": "Dict[str, List[str]]",
+    "summary": "Dict[str, Any]"
+  },
+  "TeoriaCambioInputContract": {
+    "config": "NotRequired[Dict[str, Any]]",
+    "document_text": "<class 'str'>",
+    "strategic_goals": "NotRequired[List[str]]"
+  },
+  "TeoriaCambioOutputContract": {
+    "causal_dag": "Dict[str, Any]",
+    "graph_visualizations": "NotRequired[List[Dict[str, Any]]]",
+    "monte_carlo_results": "NotRequired[Dict[str, Any]]",
+    "validation_results": "Dict[str, Any]"
+  }
+}

--- a/tests/test_contract_snapshots.py
+++ b/tests/test_contract_snapshots.py
@@ -1,0 +1,54 @@
+"""Snapshot tests that guard contract schemas."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from saaaaaa.utils import core_contracts
+
+
+SNAPSHOT_PATH = Path(__file__).parent / "data" / "contract_snapshots.json"
+
+
+def _format_type(annotation: object) -> str:
+    text = repr(annotation)
+    return text.replace("typing.", "")
+
+
+def _collect_contracts() -> Dict[str, Dict[str, str]]:
+    members: Dict[str, Dict[str, str]] = {}
+    for name in dir(core_contracts):
+        if not name.endswith("Contract"):
+            continue
+        obj = getattr(core_contracts, name)
+        annotations = getattr(obj, "__annotations__", None)
+        if not isinstance(annotations, dict):
+            continue
+        members[name] = {
+            field: _format_type(annotation)
+            for field, annotation in sorted(annotations.items())
+        }
+    return dict(sorted(members.items()))
+
+
+def test_contract_snapshots_are_stable() -> None:
+    assert SNAPSHOT_PATH.exists(), (
+        "Contract snapshot missing. Run the governance tests to regenerate "
+        "or update tests/data/contract_snapshots.json."
+    )
+
+    current = _collect_contracts()
+    stored = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    assert current == stored, (
+        "Core contract schema changed. Update tests/data/contract_snapshots.json "
+        "after stakeholder approval."
+    )

--- a/tests/test_orchestrator_golden.py
+++ b/tests/test_orchestrator_golden.py
@@ -1,0 +1,150 @@
+"""Golden-path contract tests for orchestrator executors."""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import types
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
+
+import importlib
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+if "recommendation_engine" not in sys.modules:
+    dummy = types.ModuleType("recommendation_engine")
+
+    class _DummyRecommendationEngine:
+        def __init__(self, *_, **__):
+            self.rules_by_level = {"MICRO": [], "MESO": [], "MACRO": []}
+
+        def generate_all_recommendations(self, **_kwargs):
+            return {
+                level: types.SimpleNamespace(
+                    recommendations=[],
+                    to_dict=lambda _level=level: {"level": _level, "recommendations": []},
+                )
+                for level in ("MICRO", "MESO", "MACRO")
+            }
+
+    dummy.RecommendationEngine = _DummyRecommendationEngine
+    sys.modules["recommendation_engine"] = dummy
+
+core_contracts = importlib.import_module("saaaaaa.utils.core_contracts")
+sys.modules.setdefault("core_contracts", core_contracts)
+
+from saaaaaa.core.orchestrator import executors
+from saaaaaa.core.orchestrator.core import PreprocessedDocument
+from saaaaaa.core.orchestrator.factory import CoreModuleFactory, construct_policy_processor_input
+
+
+def _contract_keys(contract: Mapping[str, object]) -> List[str]:
+    """Return the declared keys for a TypedDict class."""
+
+    annotations = getattr(contract, "__annotations__", {})
+    return sorted(annotations.keys())
+
+
+CONTRACT_KEY_MAP: Dict[str, Sequence[str]] = {
+    "IndustrialPolicyProcessor": _contract_keys(core_contracts.PolicyProcessorOutputContract),
+    "PolicyContradictionDetector": _contract_keys(core_contracts.ContradictionDetectorOutputContract),
+    "PolicyAnalysisEmbedder": _contract_keys(core_contracts.EmbeddingPolicyOutputContract),
+    "AdvancedSemanticChunker": _contract_keys(core_contracts.EmbeddingPolicyOutputContract),
+    "SemanticAnalyzer": _contract_keys(core_contracts.SemanticAnalyzerOutputContract),
+    "CDAFFramework": _contract_keys(core_contracts.CDAFFrameworkOutputContract),
+    "PDETMunicipalPlanAnalyzer": _contract_keys(core_contracts.PDETAnalyzerOutputContract),
+    "TeoriaCambio": _contract_keys(core_contracts.TeoriaCambioOutputContract),
+    "SemanticChunker": _contract_keys(core_contracts.SemanticChunkingOutputContract),
+}
+
+
+class FakeMethodExecutor:
+    """Deterministic stub for :class:`MethodExecutor`."""
+
+    def __init__(self, contract_map: Mapping[str, Sequence[str]]):
+        self.contract_map = contract_map
+        self.calls: List[Tuple[str, str]] = []
+        self.outputs: Dict[str, Dict[str, object]] = {}
+
+    def expected_keys(self, class_name: str) -> Sequence[str]:
+        return self.contract_map.get(class_name, ())
+
+    def execute(self, class_name: str, method_name: str, **kwargs):
+        self.calls.append((class_name, method_name))
+        keys = list(self.expected_keys(class_name))
+        if not keys:
+            result = {"result": f"{class_name}.{method_name}", "payload": kwargs}
+        else:
+            result = {key: f"{class_name}:{key}" for key in keys}
+        self.outputs[f"{class_name}.{method_name}"] = result
+        return result
+
+
+@pytest.fixture()
+def factory(tmp_path: Path) -> CoreModuleFactory:
+    """Provide a factory anchored to a temporary directory."""
+
+    tmp_data = tmp_path / "data"
+    tmp_data.mkdir()
+    questionnaire = tmp_data / "questionnaire_monolith.json"
+    questionnaire.write_text("{}", encoding="utf-8")
+    return CoreModuleFactory(data_dir=tmp_data)
+
+
+@pytest.fixture()
+def sample_document(factory: CoreModuleFactory, tmp_path: Path) -> Tuple[PreprocessedDocument, Dict[str, object]]:
+    """Create a sample document and policy processor input contract."""
+
+    document_path = tmp_path / "plan.txt"
+    document_path.write_text("Objetivo general. Línea base.", encoding="utf-8")
+    document_data = factory.load_document(document_path)
+    policy_input = construct_policy_processor_input(document_data)
+    preprocessed = PreprocessedDocument(
+        document_id="doc-1",
+        raw_text=document_data["raw_text"],
+        sentences=list(document_data["sentences"]),
+        tables=list(document_data["tables"]),
+        metadata={**document_data.get("metadata", {}), "document_id": "doc-1"},
+    )
+    return preprocessed, policy_input
+
+
+def _iter_executor_classes() -> Iterable[Tuple[str, type]]:
+    for name in dir(executors):
+        if not name.endswith("_Executor"):
+            continue
+        candidate = getattr(executors, name)
+        if inspect.isclass(candidate) and candidate is not executors.DataFlowExecutor:
+            yield name, candidate
+
+
+@pytest.mark.parametrize("executor_name, executor_cls", sorted(_iter_executor_classes()))
+def test_executor_golden_path_returns_contracts(
+    executor_name: str,
+    executor_cls: type,
+    sample_document: Tuple[PreprocessedDocument, Dict[str, object]],
+) -> None:
+    document, policy_input = sample_document
+    assert set(policy_input.keys()) >= {"data", "text", "sentences", "tables"}
+
+    fake_executor = FakeMethodExecutor(CONTRACT_KEY_MAP)
+    instance = executor_cls(fake_executor)
+    result_payload = instance.execute(document, fake_executor)
+
+    assert isinstance(result_payload, dict), f"{executor_name} must return a mapping"
+    assert fake_executor.calls, f"{executor_name} should invoke MethodExecutor"
+
+    for class_name, method_name in fake_executor.calls:
+        result_key = f"{class_name}.{method_name}"
+        payload = fake_executor.outputs[result_key]
+        assert isinstance(payload, dict), f"{result_key} should return dictionaries"
+        expected_keys = set(fake_executor.expected_keys(class_name))
+        if expected_keys:
+            assert expected_keys <= set(payload.keys()), (
+                f"{result_key} must expose contract keys {sorted(expected_keys)}"
+            )

--- a/tests/test_regression_semantic_chunking.py
+++ b/tests/test_regression_semantic_chunking.py
@@ -1,29 +1,36 @@
-"""
-Test suite for semantic_chunking_policy module.
+"""Regression tests for ``semantic_chunking_policy``."""
 
-Ensures that the syntax error fix (duplicate lines 555-562) stays fixed
-and tests basic functionality.
-"""
+from __future__ import annotations
 
 import ast
+import sys
 from pathlib import Path
 
 import pytest
 
 
-def test_semantic_chunking_syntax():
-    """Test that semantic_chunking_policy.py has valid syntax."""
-    module_path = Path(__file__).parent.parent / "semantic_chunking_policy.py"
-    
-    if not module_path.exists():
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+MODULE_PATH = SRC_ROOT / "saaaaaa" / "processing" / "semantic_chunking_policy.py"
+
+
+def _load_source() -> str:
+    if not MODULE_PATH.exists():
         pytest.skip("semantic_chunking_policy.py not found")
-    
-    with open(module_path, 'r', encoding='utf-8') as f:
-        source = f.read()
-    
+    return MODULE_PATH.read_text(encoding="utf-8")
+
+
+def test_semantic_chunking_syntax() -> None:
+    """The module must stay syntactically valid."""
+
+    source = _load_source()
+
     # This will raise SyntaxError if the file has syntax errors
     try:
-        ast.parse(source, filename=str(module_path))
+        ast.parse(source, filename=str(MODULE_PATH))
     except SyntaxError as e:
         pytest.fail(
             f"Syntax error in semantic_chunking_policy.py at line {e.lineno}: {e.msg}\n"
@@ -40,16 +47,10 @@ def test_no_duplicate_return_statements():
     
     This test ensures that pattern doesn't reoccur.
     """
-    module_path = Path(__file__).parent.parent / "semantic_chunking_policy.py"
-    
-    if not module_path.exists():
-        pytest.skip("semantic_chunking_policy.py not found")
-    
-    with open(module_path, 'r', encoding='utf-8') as f:
-        source = f.read()
-    
+    source = _load_source()
+
     try:
-        tree = ast.parse(source, filename=str(module_path))
+        tree = ast.parse(source, filename=str(MODULE_PATH))
     except SyntaxError:
         pytest.fail("File has syntax errors")
     
@@ -79,13 +80,7 @@ def test_no_duplicate_return_statements():
 
 def test_extract_key_excerpts_method_structure():
     """Test the structure of _extract_key_excerpts to catch similar bugs."""
-    module_path = Path(__file__).parent.parent / "semantic_chunking_policy.py"
-    
-    if not module_path.exists():
-        pytest.skip("semantic_chunking_policy.py not found")
-    
-    with open(module_path, 'r', encoding='utf-8') as f:
-        lines = f.readlines()
+    lines = _load_source().splitlines()
     
     # Look for the method definition
     method_start = None
@@ -132,13 +127,7 @@ def test_extract_key_excerpts_method_structure():
 
 def test_no_main_block():
     """Test that semantic_chunking_policy.py has no __main__ block."""
-    module_path = Path(__file__).parent.parent / "semantic_chunking_policy.py"
-    
-    if not module_path.exists():
-        pytest.skip("semantic_chunking_policy.py not found")
-    
-    with open(module_path, 'r', encoding='utf-8') as f:
-        source = f.read()
+    source = _load_source()
     
     # Simple check for __main__ block
     assert 'if __name__ == "__main__"' not in source, (


### PR DESCRIPTION
## Summary
- harden boundary governance by importing every `saaaaaa.core` module, scanning ASTs for `__main__` and I/O usage, and running an import-linter contract when available
- snapshot all core contract TypedDict schemas and add a regression test that fails on unapproved schema drift
- exercise every orchestrator executor with a golden-path harness that uses factory-built inputs and validates contract-shaped outputs, and rename the semantic chunking regression suite to its new location

## Testing
- pytest tests/test_contract_snapshots.py tests/test_orchestrator_golden.py tests/test_boundaries.py tests/test_regression_semantic_chunking.py -q

------
https://chatgpt.com/codex/tasks/task_e_690566452cd48328a5e2ae985bd68e9d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added contract snapshot validation testing to ensure schema stability
  * Implemented comprehensive executor contract verification tests
  * Enhanced module boundary and import validation tests
  * Improved semantic chunking regression test infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->