### PR TITLE
Fix meso-level aggregation to respect micro penalties

### DIFF
--- a/examples/integration_guide_bayesian.py
+++ b/examples/integration_guide_bayesian.py
@@ -222,7 +222,7 @@ class EnhancedReportAssembler:
                 peer_comparison=None,
                 peer_penalty=m['peer_penalty'],
                 total_penalty=m['total_penalty'],
-                final_posterior=m['raw_meso_score'],
+                final_posterior=m['adjusted_score'],
                 adjusted_score=m['adjusted_score']
             )
             for m in meso_analyses

--- a/src/saaaaaa/analysis/bayesian_multilevel_system.py
+++ b/src/saaaaaa/analysis/bayesian_multilevel_system.py
@@ -661,9 +661,10 @@ class BayesianRollUp:
         if not micro_analyses:
             return 0.0
         
-        # Extract posteriors
-        posteriors = [m.final_posterior for m in micro_analyses]
-        
+        # Extract posteriors (use micro-level adjusted scores so reconciliation
+        # penalties propagate into the meso aggregation)
+        posteriors = [m.adjusted_score for m in micro_analyses]
+
         # Calculate weighted mean (could use Beta-Binomial hierarchical model)
         raw_meso_posterior = np.mean(posteriors)
         
@@ -1235,7 +1236,7 @@ class MultiLevelBayesianOrchestrator:
                 peer_comparison=peer_comparison,
                 peer_penalty=peer_penalty,
                 total_penalty=total_penalty,
-                final_posterior=raw_meso_score,
+                final_posterior=adjusted_score,
                 adjusted_score=adjusted_score,
                 metadata={'question_ids': question_ids}  # Add question_ids to metadata
             )


### PR DESCRIPTION
## **User description**
## Summary
- propagate micro-level penalties through the meso roll-up by aggregating adjusted micro scores
- persist meso final posteriors after penalties instead of the raw mean
- align the integration guide example with the revised meso posterior semantics

## Testing
- pytest *(fails: pyenv reports Python 3.11.9 missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6906dd39d97483288efc8a0756e8d882


___

## **CodeAnt-AI Description**
**Propagate micro-level penalties into meso aggregation and update example**

### What Changed
- Meso-level aggregates now use micro-level adjusted scores (including micro penalties) when computing cluster posteriors, so cluster scores reflect any penalties applied to their constituent items.
- The meso result that callers see and persist (final posterior) is the post-penalty adjusted score rather than the raw mean.
- The integration example was updated so saved/returned meso posteriors match the new semantics.
- Meso analysis objects now include question IDs in metadata, making it easier to trace which items contributed to each cluster.

### Impact
`✅ Meso-level scores reflect micro penalties`
`✅ Fewer mismatched aggregate vs persisted meso values`
`✅ Integration examples produce correct persisted cluster posteriors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected the aggregation of multi-level analyses to consistently use adjusted scores across all levels, ensuring reconciliation adjustments are properly incorporated throughout the analysis hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->