### PR TITLE
Ensure orchestrator questionnaire provider manages monolith

### DIFF
--- a/src/saaaaaa/core/orchestrator/__init__.py
+++ b/src/saaaaaa/core/orchestrator/__init__.py
@@ -1,58 +1,195 @@
 """Orchestrator utilities with contract validation on import."""
+from __future__ import annotations
+
 import inspect
+import json
+from pathlib import Path
 from threading import RLock
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 class _QuestionnaireProvider:
     """Centralized access to the questionnaire monolith payload.
-    
-    This is now a pure data holder - I/O operations have been moved to factory.py.
-    The provider receives pre-loaded data and manages caching.
+
+    The provider is responsible for wiring the orchestrator to the canonical
+    ``questionnaire_monolith.json`` file.  It offers a small utility surface
+    that mirrors the historical API (``load``/``exists``/``describe``/``save``)
+    so the legacy orchestrator package and external tooling (scripts/tests)
+    continue to function while newer code paths inject pre-loaded data via
+    :meth:`set_data`.
     """
-    
-    def __init__(self, initial_data: Optional[Dict[str, Any]] = None) -> None:
-        """Initialize provider with optional pre-loaded data.
-        
-        Args:
-            initial_data: Pre-loaded questionnaire data. If None, data must be
-                         set via set_data() before calling get_data().
-        """
-        self._cache: Optional[Dict[str, Any]] = initial_data
+
+    _DEFAULT_RELATIVE_PATH = Path("data") / "questionnaire_monolith.json"
+
+    def __init__(
+        self,
+        initial_data: Optional[Dict[str, Any]] = None,
+        data_path: Optional[Union[str, Path]] = None,
+    ) -> None:
+        """Initialise provider with optional pre-loaded data and path hint."""
+
         self._lock = RLock()
-    
+        self._cache: Optional[Dict[str, Any]] = initial_data
+        if data_path is None:
+            self._data_path = self._default_repo_root() / self._DEFAULT_RELATIVE_PATH
+        else:
+            self._data_path = self._coerce_path(data_path)
+
+    @staticmethod
+    def _default_repo_root() -> Path:
+        """Return repository root used to resolve the questionnaire path."""
+
+        return Path(__file__).resolve().parents[4]
+
+    def _coerce_path(self, candidate: Union[str, Path]) -> Path:
+        path = Path(candidate)
+        if not path.is_absolute():
+            path = (Path.cwd() / path).resolve()
+        return path
+
+    def _resolve_path(self, candidate: Optional[Union[str, Path]]) -> Path:
+        """Resolve *candidate* to an absolute path, defaulting to ``data_path``."""
+
+        if candidate is None:
+            return self._data_path
+        return self._coerce_path(candidate)
+
+    @property
+    def data_path(self) -> Path:
+        """Return the resolved path of the canonical questionnaire payload."""
+
+        return self._data_path
+
     def set_data(self, data: Dict[str, Any]) -> None:
-        """Set questionnaire data (typically called by factory).
-        
-        Args:
-            data: Questionnaire payload dictionary
+        """Inject pre-loaded questionnaire data (typically provided by factory).
+
+        The provider caches the payload so subsequent :meth:`load` calls can
+        re-use the in-memory copy without hitting the filesystem.
         """
+
         with self._lock:
             self._cache = data
-    
+
     def get_data(self) -> Dict[str, Any]:
-        """Get cached questionnaire data.
-        
-        Returns:
-            Questionnaire payload dictionary
-            
+        """Return the cached questionnaire data.
+
         Raises:
-            RuntimeError: If no data has been loaded yet
+            RuntimeError: If the questionnaire has not been loaded or injected
+                yet.
         """
+
         with self._lock:
             if self._cache is None:
                 raise RuntimeError(
                     "Questionnaire data not loaded. Use factory.py to load data first."
                 )
             return self._cache
-    
+
     def has_data(self) -> bool:
-        """Check if data is loaded.
-        
-        Returns:
-            True if data is available, False otherwise
-        """
+        """Return ``True`` when an in-memory questionnaire payload is cached."""
+
         with self._lock:
             return self._cache is not None
+
+    # ------------------------------------------------------------------
+    # Legacy compatibility helpers
+    # ------------------------------------------------------------------
+
+    def exists(self, data_path: Optional[Union[str, Path]] = None) -> bool:
+        """Check whether a questionnaire payload exists on disk."""
+
+        return self._resolve_path(data_path).exists()
+
+    def describe(self, data_path: Optional[Union[str, Path]] = None) -> Dict[str, Any]:
+        """Return filesystem metadata for the questionnaire payload."""
+
+        path = self._resolve_path(data_path)
+        exists = path.exists()
+        size = path.stat().st_size if exists else 0
+        return {"path": path, "exists": exists, "size": size}
+
+    def _read_payload(self, path: Path) -> Dict[str, Any]:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def load(
+        self,
+        *,
+        force_reload: bool = False,
+        data_path: Optional[Union[str, Path]] = None,
+    ) -> Dict[str, Any]:
+        """Load and optionally cache the questionnaire payload from disk.
+
+        When ``data_path`` is ``None`` the canonical monolith is used.  The
+        result is cached unless ``force_reload`` is ``True``.  Supplying a
+        custom ``data_path`` bypasses the cache so callers can inspect arbitrary
+        payloads without mutating the shared state.
+        """
+
+        target_path = self._resolve_path(data_path)
+        with self._lock:
+            if data_path is None:
+                if self._cache is not None and not force_reload:
+                    return self._cache
+                if not target_path.exists():
+                    raise FileNotFoundError(
+                        f"Questionnaire payload missing at {target_path}"
+                    )
+                self._cache = self._read_payload(target_path)
+                return self._cache
+
+            if not target_path.exists():
+                raise FileNotFoundError(
+                    f"Questionnaire payload missing at {target_path}"
+                )
+            return self._read_payload(target_path)
+
+    def save(
+        self,
+        payload: Dict[str, Any],
+        *,
+        output_path: Optional[Union[str, Path]] = None,
+    ) -> Path:
+        """Persist a questionnaire payload to disk and refresh the cache."""
+
+        target_path = self._resolve_path(output_path)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        with target_path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, ensure_ascii=False, sort_keys=True)
+
+        with self._lock:
+            self._cache = payload
+            if output_path is not None:
+                self._data_path = target_path
+        return target_path
+
+    def get_question(self, question_global: int) -> Dict[str, Any]:
+        """Return a single question entry from the cached payload."""
+
+        payload = self.load()
+        blocks = payload.get("blocks")
+        if not isinstance(blocks, dict):
+            raise ValueError("The questionnaire payload is missing the 'blocks' mapping")
+
+        def _iter_questions():
+            micro = blocks.get("micro_questions") or []
+            if isinstance(micro, list):
+                for item in micro:
+                    if isinstance(item, dict):
+                        yield item
+            meso = blocks.get("meso_questions") or []
+            if isinstance(meso, list):
+                for item in meso:
+                    if isinstance(item, dict):
+                        yield item
+            macro = blocks.get("macro_question")
+            if isinstance(macro, dict):
+                yield macro
+
+        for question in _iter_questions():
+            if question.get("question_global") == question_global:
+                return question
+
+        raise KeyError(f"Question {question_global} not present in questionnaire payload")
 
 _questionnaire_provider = _QuestionnaireProvider()
 


### PR DESCRIPTION
## **User description**
## Summary
- extend the core orchestrator questionnaire provider to resolve the canonical monolith path
- expose legacy helper methods (load/exists/describe/save/get_question) so scripts and tests can interact with the monolith data
- keep the shared cache in sync when data is injected or persisted, updating the default data path on explicit saves

## Testing
- `pytest tests/test_smoke_orchestrator.py::test_import_orchestrator_package tests/test_smoke_orchestrator.py::test_provider_boundary_guard -q` *(fails: pyenv environment is missing python 3.11.9)*

------
https://chatgpt.com/codex/tasks/task_e_6906dd8045c883289807b6ec0300d993


___

## **CodeAnt-AI Description**
**Wire questionnaire provider to canonical monolith file and add load/save/inspect helpers**

### What Changed
- The orchestrator's questionnaire provider now knows and exposes the canonical monolith file location so tooling and the orchestrator share the same default payload file.
- You can inject a pre-loaded questionnaire and the provider caches it for reuse; callers can also explicitly load the payload from disk (with optional force-reload) and save updated payloads back to disk.
- New helper operations allow scripts and tests to:
  - check whether a monolith file exists and get simple filesystem metadata,
  - load a payload from an arbitrary path without changing the shared cache,
  - save a payload to disk and refresh the in-memory copy (saving to a custom path updates the provider's default path),
  - retrieve a single question by its global id (searches micro/meso/macro blocks).
- Error behavior is now explicit to callers: attempting to load a missing file raises a file-not-found error, requesting a question that does not exist raises a key error, and accessing the payload before it's available raises a clear runtime error.

### Impact
`✅ Scripts and tests can read and write the canonical questionnaire file`
`✅ Can fetch a specific question by global id for focused inspection`
`✅ Saved payloads immediately become the in-memory questionnaire used by the orchestrator`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
