### PR TITLE
Normalize macro flux metrics before recommendation analysis

### DIFF
--- a/src/saaaaaa/core/orchestrator/ORCHESTRATOR_MONILITH.py
+++ b/src/saaaaaa/core/orchestrator/ORCHESTRATOR_MONILITH.py
@@ -10445,8 +10445,13 @@ class Orchestrator:
         macro_score = sum(valid_scores) / len(valid_scores) if valid_scores else None
 
         instrumentation.increment(latency=time.perf_counter() - start)
+        macro_score_normalized = (
+            macro_score / 3.0 if macro_score is not None else None
+        )
+
         return {
             "macro_score": macro_score,
+            "macro_score_normalized": macro_score_normalized,
             "cluster_scores": cluster_scores,
         }
 
@@ -10528,21 +10533,31 @@ class Orchestrator:
                 areas = cluster.get('areas', [])
 
                 if cluster_id and cluster_score is not None:
-                    # Calculate variance across areas in this cluster
-                    area_scores = [area.get('score', 0) for area in areas if area.get('score') is not None]
-                    variance = statistics.variance(area_scores) if len(area_scores) > 1 else 0.0
+                    normalized_cluster_score = cluster_score / 3.0
+
+                    # Calculate variance across areas in this cluster using normalized scores
+                    valid_area_scores = [
+                        (area, area.get('score') / 3.0)
+                        for area in areas
+                        if area.get('score') is not None
+                    ]
+                    normalized_area_values = [score for _, score in valid_area_scores]
+                    variance = (
+                        statistics.variance(normalized_area_values)
+                        if len(normalized_area_values) > 1
+                        else 0.0
+                    )
 
                     # Find weakest policy area in cluster
-                    weak_pa = None
-                    if area_scores:
-                        min_score = min(area_scores)
-                        for area in areas:
-                            if area.get('score') == min_score:
-                                weak_pa = area.get('area_id')
-                                break
+                    weakest_area = (
+                        min(valid_area_scores, key=lambda item: item[1])
+                        if valid_area_scores
+                        else None
+                    )
+                    weak_pa = weakest_area[0].get('area_id') if weakest_area else None
 
                     cluster_data[cluster_id] = {
-                        'score': cluster_score * 100,  # Convert to 0-100 scale
+                        'score': normalized_cluster_score * 100,  # 0-100 scale
                         'variance': variance,
                         'weak_pa': weak_pa
                     }
@@ -10553,11 +10568,15 @@ class Orchestrator:
             # MACRO LEVEL: Transform macro evaluation
             # ========================================================================
             macro_score = macro_result.get('macro_score')
+            macro_score_normalized = macro_result.get('macro_score_normalized')
+
+            if macro_score is not None and macro_score_normalized is None:
+                macro_score_normalized = macro_score / 3.0
 
             # Determine macro band based on score
             macro_band = 'INSUFICIENTE'
-            if macro_score is not None:
-                scaled_score = macro_score * 100
+            if macro_score_normalized is not None:
+                scaled_score = macro_score_normalized * 100
                 if scaled_score >= 75:
                     macro_band = 'SATISFACTORIO'
                 elif scaled_score >= 55:
@@ -10570,12 +10589,20 @@ class Orchestrator:
             for cluster in cluster_scores:
                 cluster_id = cluster.get('cluster_id')
                 cluster_score = cluster.get('score', 0)
-                if cluster_score * 100 < 55:
+                if cluster_score is not None and (cluster_score / 3.0) * 100 < 55:
                     clusters_below_target.append(cluster_id)
 
             # Calculate overall variance
-            all_cluster_scores = [c.get('score', 0) for c in cluster_scores if c.get('score') is not None]
-            overall_variance = statistics.variance(all_cluster_scores) if len(all_cluster_scores) > 1 else 0.0
+            normalized_cluster_scores = [
+                c.get('score') / 3.0
+                for c in cluster_scores
+                if c.get('score') is not None
+            ]
+            overall_variance = (
+                statistics.variance(normalized_cluster_scores)
+                if len(normalized_cluster_scores) > 1
+                else 0.0
+            )
 
             variance_alert = 'BAJA'
             if overall_variance >= 0.18:
@@ -10585,13 +10612,16 @@ class Orchestrator:
 
             # Find priority micro gaps (lowest scoring PA-DIM combinations)
             sorted_micro = sorted(micro_scores.items(), key=lambda x: x[1])
-            priority_micro_gaps = [k for k, v in sorted_micro[:5] if v < 1.65]
+            priority_micro_gaps = [k for k, v in sorted_micro[:5] if v < 0.55]
 
             macro_data = {
                 'macro_band': macro_band,
                 'clusters_below_target': clusters_below_target,
                 'variance_alert': variance_alert,
-                'priority_micro_gaps': priority_micro_gaps
+                'priority_micro_gaps': priority_micro_gaps,
+                'macro_score_percentage': (
+                    macro_score_normalized * 100 if macro_score_normalized is not None else None
+                )
             }
 
             logger.info(f"Macro band: {macro_band}, Clusters below target: {len(clusters_below_target)}")
@@ -10616,6 +10646,7 @@ class Orchestrator:
                 level: rec_set.to_dict() for level, rec_set in recommendation_sets.items()
             }
             recommendations['macro_score'] = macro_score
+            recommendations['macro_score_normalized'] = macro_score_normalized
 
             logger.info(
                 f"Generated recommendations: "

--- a/src/saaaaaa/core/orchestrator/core.py
+++ b/src/saaaaaa/core/orchestrator/core.py
@@ -1566,8 +1566,13 @@ class Orchestrator:
         macro_score = sum(valid_scores) / len(valid_scores) if valid_scores else None
 
         instrumentation.increment(latency=time.perf_counter() - start)
+        macro_score_normalized = (
+            macro_score / 3.0 if macro_score is not None else None
+        )
+
         return {
             "macro_score": macro_score,
+            "macro_score_normalized": macro_score_normalized,
             "cluster_scores": cluster_scores,
         }
 
@@ -1649,21 +1654,31 @@ class Orchestrator:
                 areas = cluster.get('areas', [])
 
                 if cluster_id and cluster_score is not None:
-                    # Calculate variance across areas in this cluster
-                    area_scores = [area.get('score', 0) for area in areas if area.get('score') is not None]
-                    variance = statistics.variance(area_scores) if len(area_scores) > 1 else 0.0
+                    normalized_cluster_score = cluster_score / 3.0
+
+                    # Calculate variance across areas in this cluster using normalized scores
+                    valid_area_scores = [
+                        (area, area.get('score') / 3.0)
+                        for area in areas
+                        if area.get('score') is not None
+                    ]
+                    normalized_area_values = [score for _, score in valid_area_scores]
+                    variance = (
+                        statistics.variance(normalized_area_values)
+                        if len(normalized_area_values) > 1
+                        else 0.0
+                    )
 
                     # Find weakest policy area in cluster
-                    weak_pa = None
-                    if area_scores:
-                        min_score = min(area_scores)
-                        for area in areas:
-                            if area.get('score') == min_score:
-                                weak_pa = area.get('area_id')
-                                break
+                    weakest_area = (
+                        min(valid_area_scores, key=lambda item: item[1])
+                        if valid_area_scores
+                        else None
+                    )
+                    weak_pa = weakest_area[0].get('area_id') if weakest_area else None
 
                     cluster_data[cluster_id] = {
-                        'score': cluster_score * 100,  # Convert to 0-100 scale
+                        'score': normalized_cluster_score * 100,  # 0-100 scale
                         'variance': variance,
                         'weak_pa': weak_pa
                     }
@@ -1674,11 +1689,15 @@ class Orchestrator:
             # MACRO LEVEL: Transform macro evaluation
             # ========================================================================
             macro_score = macro_result.get('macro_score')
+            macro_score_normalized = macro_result.get('macro_score_normalized')
+
+            if macro_score is not None and macro_score_normalized is None:
+                macro_score_normalized = macro_score / 3.0
 
             # Determine macro band based on score
             macro_band = 'INSUFICIENTE'
-            if macro_score is not None:
-                scaled_score = macro_score * 100
+            if macro_score_normalized is not None:
+                scaled_score = macro_score_normalized * 100
                 if scaled_score >= 75:
                     macro_band = 'SATISFACTORIO'
                 elif scaled_score >= 55:
@@ -1691,12 +1710,20 @@ class Orchestrator:
             for cluster in cluster_scores:
                 cluster_id = cluster.get('cluster_id')
                 cluster_score = cluster.get('score', 0)
-                if cluster_score * 100 < 55:
+                if cluster_score is not None and (cluster_score / 3.0) * 100 < 55:
                     clusters_below_target.append(cluster_id)
 
             # Calculate overall variance
-            all_cluster_scores = [c.get('score', 0) for c in cluster_scores if c.get('score') is not None]
-            overall_variance = statistics.variance(all_cluster_scores) if len(all_cluster_scores) > 1 else 0.0
+            normalized_cluster_scores = [
+                c.get('score') / 3.0
+                for c in cluster_scores
+                if c.get('score') is not None
+            ]
+            overall_variance = (
+                statistics.variance(normalized_cluster_scores)
+                if len(normalized_cluster_scores) > 1
+                else 0.0
+            )
 
             variance_alert = 'BAJA'
             if overall_variance >= 0.18:
@@ -1706,13 +1733,16 @@ class Orchestrator:
 
             # Find priority micro gaps (lowest scoring PA-DIM combinations)
             sorted_micro = sorted(micro_scores.items(), key=lambda x: x[1])
-            priority_micro_gaps = [k for k, v in sorted_micro[:5] if v < 1.65]
+            priority_micro_gaps = [k for k, v in sorted_micro[:5] if v < 0.55]
 
             macro_data = {
                 'macro_band': macro_band,
                 'clusters_below_target': clusters_below_target,
                 'variance_alert': variance_alert,
-                'priority_micro_gaps': priority_micro_gaps
+                'priority_micro_gaps': priority_micro_gaps,
+                'macro_score_percentage': (
+                    macro_score_normalized * 100 if macro_score_normalized is not None else None
+                )
             }
 
             logger.info(f"Macro band: {macro_band}, Clusters below target: {len(clusters_below_target)}")
@@ -1737,6 +1767,7 @@ class Orchestrator:
                 level: rec_set.to_dict() for level, rec_set in recommendation_sets.items()
             }
             recommendations['macro_score'] = macro_score
+            recommendations['macro_score_normalized'] = macro_score_normalized
 
             logger.info(
                 f"Generated recommendations: "


### PR DESCRIPTION
## **User description**
## Summary
- normalize macro-level scores before computing meso variance, macro bands, and cluster thresholds
- add normalized macro score metadata to both orchestration implementations for downstream consumers
- align micro gap filter with 55% threshold and expose macro percentage for recommendation context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6906dd41cadc83289c8b33ed4303e7f2


___

## **CodeAnt-AI Description**
**Normalize scores before recommendation analysis and expose normalized macro metrics**

### What Changed
- All macro, cluster and area scores are normalized to a 0–1 range before any variance, banding or gap calculations; cluster scores shown to users are still reported as 0–100 but are derived from the normalized values.
- Variance and macro band decisions (SATISFACTORIO / ACEPTABLE / DEFICIENTE / INSUFICIENTE) now use the normalized score percentage, and clusters counted as "below target" use the normalized percentage threshold (<55%).
- Micro-level priority gaps filter was tightened (previous cutoff equivalent to ~1.65 is now ~0.55 on the normalized scale), reducing low-priority micro recommendations.
- Recommendation outputs and downstream consumers now receive explicit normalized macro metrics: macro_score_normalized and macro_score_percentage are included alongside the original macro_score.

### Impact
`✅ Clearer macro score percentage in recommendation payloads`
`✅ Fewer low-priority micro gap suggestions`
`✅ Consistent cluster ranking and variance alerts across reports`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
